### PR TITLE
Refactor: use Bootstrap

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,8 +58,8 @@
             {% include certs.html %}
 
         </div>
-        <div class="">
-            <div class="">
+        <div class="d-flex social-media-container">
+            <div class="d-flex justify-content-between align-items-end py-4">
                 <a href="https://github.com/compilerla"><img class="social-media-icon"
                         src="/assets/social_media/github_mark.png" alt="GitHub"></a>
                 <a href="https://twitter.com/CompilerLA"><img class="social-media-icon"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,8 +46,8 @@
     </main>
 
     <footer>
-        <div class="divider-line my-5"></div>
-        <div class="certs">
+        <div class="divider-line"></div>
+        <div class="certs d-flex flex-column flex-lg-row row-cols-lg-4">
             <div>
                 <a href="mailto:hello@compiler.la" class="monospace contact-link">hello@compiler.la</a>
                 <p class="address">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,7 +44,7 @@
 
     <footer>
         <div class="divider-line"></div>
-        <div class="row certs shifted-down">
+        <div class="certs">
             <div>
                 <a href="mailto:hello@compiler.la" class="monospace contact-link">hello@compiler.la</a>
                 <p class="address">
@@ -55,17 +55,14 @@
             {% include certs.html %}
 
         </div>
-        <div class="row">
-            <div class="social-media-container">
-                <a href="https://github.com/compilerla">
-                    <img class="social-media-icon" src="/assets/social_media/github_mark.png" alt="GitHub">
-                </a>
-                <a href="https://twitter.com/CompilerLA">
-                    <img class="social-media-icon" src="/assets/social_media/twitter_logo.svg" alt="Twitter">
-                </a>
-                <a href="https://www.linkedin.com/company/compiler-la">
-                    <img class="social-media-icon" src="/assets/social_media/linkedin_in.png" alt="LinkedIn">
-                </a>
+        <div class="">
+            <div class="">
+                <a href="https://github.com/compilerla"><img class="social-media-icon"
+                        src="/assets/social_media/github_mark.png" alt="GitHub"></a>
+                <a href="https://twitter.com/CompilerLA"><img class="social-media-icon"
+                        src="/assets/social_media/twitter_logo.svg" alt="Twitter"></a>
+                <a href="https://www.linkedin.com/company/compiler-la"><img class="social-media-icon"
+                        src="/assets/social_media/linkedin_in.png" alt="LinkedIn"></a>
             </div>
             <img class="brandmark" src="/assets/compiler_brandmark.svg" alt="Compiler brandmark">
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,9 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
+
     <link type="text/css" rel="stylesheet" href="/styles/base.css">
 
     <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,7 +46,7 @@
     </main>
 
     <footer>
-        <div class="divider-line"></div>
+        <div class="divider-line my-5"></div>
         <div class="certs">
             <div>
                 <a href="mailto:hello@compiler.la" class="monospace contact-link">hello@compiler.la</a>

--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -6,6 +6,6 @@ title_prefix: "Jobs with Compiler:"
 
 {{ content }}
 
-<div class="shifted-down">
+<div class="">
     <a class="monospace title-lg" href="/jobs">Back to Jobs</a>
 </div>

--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -7,5 +7,5 @@ title_prefix: "Jobs with Compiler:"
 {{ content }}
 
 <div class="">
-    <a class="monospace title-lg" href="/jobs">Back to Jobs</a>
+    <a class="monospace lg-link" href="/jobs">Back to Jobs</a>
 </div>

--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -6,6 +6,6 @@ title_prefix: "Jobs with Compiler:"
 
 {{ content }}
 
-<div class="">
+<div>
     <a class="monospace lg-link" href="/jobs">Back to Jobs</a>
 </div>

--- a/index.html
+++ b/index.html
@@ -2,11 +2,11 @@
 layout: default
 description: We build open-source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 ---
-<div class="">
+<div class="row py-5">
     <h1 class="san-serif">we build software for the government</h1>
+</div>
 
-    <div class="">
-        <a class="monospace btn-link primary-btn" href="/capabilities">Capabilities Statement</a>
-        <a class="monospace btn-link secondary-btn" href="mailto:hello@compiler.la">Get in touch</a>
-    </div>
+<div class="d-flex flex-column flex-lg-row mb-5">
+    <a class="monospace btn-link primary-btn" href="/capabilities">Capabilities Statement</a>
+    <a class="monospace btn-link secondary-btn" href="mailto:hello@compiler.la">Get in touch</a>
 </div>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ description: We build open-source, human-centered, secure, agile solutions to su
     <h1 class="san-serif">we build software for the government</h1>
 
     <div class="">
-        <a class="monospace text-lg primary-btn" href="/capabilities">Capabilities Statement</a>
-        <a class="monospace text-lg secondary-btn" href="mailto:hello@compiler.la">Get in touch</a>
+        <a class="monospace btn-link primary-btn" href="/capabilities">Capabilities Statement</a>
+        <a class="monospace btn-link secondary-btn" href="mailto:hello@compiler.la">Get in touch</a>
     </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 layout: default
 description: We build open-source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 ---
-<div class="shifted-down">
+<div class="">
     <h1 class="san-serif">we build software for the government</h1>
 
-    <div class="row shifted-down">
+    <div class="">
         <a class="monospace text-lg primary-btn" href="/capabilities">Capabilities Statement</a>
         <a class="monospace text-lg secondary-btn" href="mailto:hello@compiler.la">Get in touch</a>
     </div>

--- a/jobs.html
+++ b/jobs.html
@@ -2,9 +2,9 @@
 layout: default
 title: Jobs with Compiler
 ---
-<h1 class="my-4">Jobs</h1>
+<h1>Jobs</h1>
 
-<h2 class="my-3">Accepting applications</h2>
+<h2">Accepting applications</h2>
 {% assign open_jobs = site.jobs | where: "open", "true" %}
 {% if open_jobs.size > 0 %}
 <ul>
@@ -16,7 +16,7 @@ title: Jobs with Compiler
 <p>There are no positions accepting applications at the moment.</p>
 {% endif %}
 
-<h2 class="my-3">Past opportunities</h2>
+<h2>Past opportunities</h2>
 <ul class="mx-3">
     {% for job in site.jobs %}
     {% if job.open != true %}

--- a/jobs.html
+++ b/jobs.html
@@ -4,7 +4,7 @@ title: Jobs with Compiler
 ---
 <h1>Jobs</h1>
 
-<h2">Accepting applications</h2>
+<h2>Accepting applications</h2>
 {% assign open_jobs = site.jobs | where: "open", "true" %}
 {% if open_jobs.size > 0 %}
 <ul>

--- a/jobs.html
+++ b/jobs.html
@@ -2,9 +2,9 @@
 layout: default
 title: Jobs with Compiler
 ---
-<h1>Jobs</h1>
+<h1 class="my-4">Jobs</h1>
 
-<h2>Accepting applications</h2>
+<h2 class="my-3">Accepting applications</h2>
 {% assign open_jobs = site.jobs | where: "open", "true" %}
 {% if open_jobs.size > 0 %}
 <ul>
@@ -16,8 +16,8 @@ title: Jobs with Compiler
 <p>There are no positions accepting applications at the moment.</p>
 {% endif %}
 
-<h2>Past opportunities</h2>
-<ul>
+<h2 class="my-3">Past opportunities</h2>
+<ul class="mx-3">
     {% for job in site.jobs %}
     {% if job.open != true %}
     <li><a href="{{ job.url }}">{{ job.title }}</a></li>
@@ -25,7 +25,7 @@ title: Jobs with Compiler
     {% endfor %}
 </ul>
 
-<p>
+<p class="mb-5">
     Missed a past opportunity? <a href="http://eepurl.com/h6qTKL">Subscribe</a> to our mailing list, as we are always
     looking for great candidates.
 </p>

--- a/styles/base.css
+++ b/styles/base.css
@@ -79,7 +79,7 @@ li.certs {
     padding-bottom: 0.75rem;
 }
 
-/* Font Family */
+/*#region Font Family */
 
 .monospace,
 h1,
@@ -95,7 +95,9 @@ h6 {
     font-family: 'Roboto', Arial, Helvetica, sans-serif;
 }
 
-/* Font Sizes */
+/*#endregion */
+
+/*#region Font Sizes */
 
 :root {
     --title-font-size: 1.75rem;
@@ -116,6 +118,37 @@ h6 {
 .btn-link {
     font-size: var(--button-text-font-size);
 }
+
+/*
+Overwrite Bootstrap's heading font-sizes
+https://stackoverflow.com/questions/5410066/what-are-the-default-font-sizes-in-pixels-for-the-html-heading-tags-h1-h2
+*/
+
+h1 {
+    font-size: 2rem;
+}
+
+h2 {
+    font-size: 1.5rem;
+}
+
+h3 {
+    font-size: 1.17rem;
+}
+
+h4 {
+    font-size: 1rem;
+}
+
+h5 {
+    font-size: 0.83rem;
+}
+
+h6 {
+    font-size: 0.67rem;
+}
+
+/*#endregion */
 
 .primary-btn {
     text-decoration: none;

--- a/styles/base.css
+++ b/styles/base.css
@@ -126,10 +126,14 @@ https://stackoverflow.com/questions/5410066/what-are-the-default-font-sizes-in-p
 
 h1 {
     font-size: 2rem;
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
 }
 
 h2 {
     font-size: 1.5rem;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
 }
 
 h3 {

--- a/styles/base.css
+++ b/styles/base.css
@@ -223,17 +223,3 @@ footer .address {
         width: 8rem;
     }
 }
-
-@media (max-height: 30rem) {
-    .logo {
-        width: 15rem;
-    }
-
-    .title-lg {
-        font-size: 1.75rem;
-    }
-
-    .text-lg {
-        font-size: 1.25rem;
-    }
-}

--- a/styles/base.css
+++ b/styles/base.css
@@ -72,10 +72,6 @@ li.certs {
     font-size: 1.5rem;
 }
 
-.shifted-down {
-    margin-top: 50px;
-}
-
 .primary-btn {
     text-decoration: none;
     border: 3px solid var(--green);
@@ -106,11 +102,6 @@ li.certs {
     background-color: var(--green);
 }
 
-.row {
-    display: flex;
-    flex-wrap: wrap;
-}
-
 header {
     margin-left: -10px; /* account for padding within the Compiler logo*/
 }
@@ -132,15 +123,6 @@ footer {
     flex-shrink: 0;
 }
 
-footer .row {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
-    flex-wrap: wrap;
-
-    padding: 1rem 0;
-}
-
 footer .heading {
     font-size: 1.5rem;
     color: var(--teal);
@@ -155,22 +137,6 @@ footer .contact-link {
 
 footer .address {
     margin-top: 24px;
-}
-
-footer .certs > div {
-    flex: 1 1 0px;
-    align-self: flex-start;
-    padding: 0 20px;
-}
-
-footer .certs > div:first-child  {
-    padding-left: 0;
-}
-
-.social-media-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
 }
 
 .social-media-icon {
@@ -256,11 +222,5 @@ footer .certs > div:first-child  {
 
     .text-lg {
         font-size: 1.25rem;
-    }
-}
-
-@media (max-height: 25rem) {
-    header {
-        padding-bottom: 10px;
     }
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -21,19 +21,27 @@ body {
     margin: 0;
 }
 
+:root {
+    --body-padding: 16px;
+}
+
+@media (min-width: 992px) {
+    :root {
+        --body-padding: 30px;
+    }
+}
+
 body {
     display: flex;
     flex-direction: column;
 
-    padding: 30px;
+    padding: var(--body-padding);
     background-color: var(--off-black);
 
     color: var(--white);
     font-family: 'Roboto', Arial, Helvetica, sans-serif;
     font-weight: normal;
 }
-
-
 
 p,
 li {
@@ -54,12 +62,20 @@ a:focus {
 ul.no-bullets {
     list-style-type: none;
     padding: 0;
-    margin: inherit 0 0;
+    margin: 16px 0;
+}
+
+@media (min-width: 992px) {
+    ul.no-bullets li {
+        margin: inherit 0 0;
+    }
 }
 
 li.certs {
     padding-bottom: 0.75rem;
 }
+
+/* Font Family */
 
 .monospace,
 h1,
@@ -75,12 +91,26 @@ h6 {
     font-family: 'Roboto', Arial, Helvetica, sans-serif;
 }
 
-.title-lg {
-    font-size: 2rem;
+/* Font Sizes */
+
+:root {
+    --title-font-size: 1.75rem;
+    --button-text-font-size: 1.25rem;
 }
 
-.text-lg {
-    font-size: 1.5rem;
+@media (min-width: 992px) {
+    :root {
+        --title-font-size: 2rem;
+        --button-text-font-size: 1.5rem;
+    }
+}
+
+.lg-link {
+    font-size: var(--title-font-size);
+}
+
+.btn-link {
+    font-size: var(--button-text-font-size);
 }
 
 .primary-btn {
@@ -113,22 +143,47 @@ h6 {
     background-color: var(--green);
 }
 
+/* Header */
+
+:root {
+    --header-margin-left: -5px;
+    --logo-width: 15rem;
+}
+
+@media (min-width: 992px) {
+    :root {
+        --header-margin-left: -10px;
+        --logo-width: 20rem;
+    }
+}
+
 header {
-    margin-left: -10px;
+    margin-left: var(--header-margin-left);
     /* account for padding within the Compiler logo*/
 }
 
 .logo {
-    width: 20rem;
+    width: var(--logo-width);
 }
+
+/* Main */
 
 main {
     flex: 1 0 auto;
 }
 
+/* Footer */
+
 .divider-line {
     border-top: 1px solid #545454;
-    margin: 125px -30px 0px;
+    margin: 120px -16px -75px;
+}
+
+@media (min-width: 992px) {
+    .divider-line {
+        margin: 125px -30px 0px;
+    }
+
 }
 
 footer {
@@ -153,9 +208,16 @@ footer .address {
 
 .social-media-icon {
     opacity: 40%;
-    margin: 0 24px;
-    width: 3rem;
     transition: 250ms;
+    margin: 0 12px;
+    width: calc(28rem / 16);
+}
+
+@media (min-width: 992px) {
+    .social-media-icon {
+        margin: 0 24px;
+        width: 3rem;
+    }
 }
 
 .social-media-container a:first-child .social-media-icon {
@@ -168,58 +230,13 @@ footer .address {
 }
 
 .brandmark {
-    width: 17.5rem;
+    width: 8rem;
     margin-right: -15px;
     margin-left: auto;
 }
 
-/***** Media Queries *****/
-
-/* - with default font 16px, 48rem = 768px */
-@media (max-width: 48rem) {
-    body {
-        padding: 16px;
-    }
-
-    header {
-        margin-left: -5px;
-    }
-
-    .logo {
-        width: 15rem;
-    }
-
-    .title-lg {
-        font-size: 1.75rem;
-    }
-
-    .text-lg {
-        font-size: 1.25rem;
-    }
-
-    .divider-line {
-        margin: 120px -16px -75px;
-    }
-
-    footer .certs {
-        flex-direction: column;
-    }
-
-    footer .certs>div {
-        margin: 48px 0 0;
-        padding: 0;
-    }
-
-    ul.no-bullets li {
-        margin: 16px 0;
-    }
-
-    .social-media-icon {
-        margin: 0 12px;
-        width: calc(28rem / 16);
-    }
-
+@media (min-width: 992px) {
     .brandmark {
-        width: 8rem;
+        width: 17.5rem;
     }
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -176,12 +176,12 @@ main {
 
 .divider-line {
     border-top: 1px solid #545454;
-    margin: 120px -16px -75px;
+    margin: 10px -16px 10px;
 }
 
 @media (min-width: 992px) {
     .divider-line {
-        margin: 125px -30px 0px;
+        margin: 20px -30px 20px;
     }
 
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -15,7 +15,8 @@
     box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
     height: 100%;
     margin: 0;
 }
@@ -32,7 +33,10 @@ body {
     font-weight: normal;
 }
 
-p, li {
+
+
+p,
+li {
     line-height: 1.5rem;
 }
 
@@ -42,7 +46,8 @@ a {
     transition: 250ms;
 }
 
-a:hover, a:focus {
+a:hover,
+a:focus {
     color: var(--green);
 }
 
@@ -56,7 +61,13 @@ li.certs {
     padding-bottom: 0.75rem;
 }
 
-.monospace, h1, h2, h3, h4, h5, h6 {
+.monospace,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
     font-family: 'Source Code Pro Bold', 'Courier New', Courier, monospace;
 }
 
@@ -103,7 +114,8 @@ li.certs {
 }
 
 header {
-    margin-left: -10px; /* account for padding within the Compiler logo*/
+    margin-left: -10px;
+    /* account for padding within the Compiler logo*/
 }
 
 .logo {
@@ -150,7 +162,8 @@ footer .address {
     margin-left: 0px;
 }
 
-.social-media-icon:hover, .social-media-icon:focus {
+.social-media-icon:hover,
+.social-media-icon:focus {
     opacity: 100%;
 }
 
@@ -192,7 +205,7 @@ footer .address {
         flex-direction: column;
     }
 
-    footer .certs > div {
+    footer .certs>div {
         margin: 48px 0 0;
         padding: 0;
     }

--- a/styles/base.css
+++ b/styles/base.css
@@ -60,6 +60,10 @@ a:focus {
 }
 
 ul.no-bullets {
+    padding-left: 0;
+}
+
+ul.no-bullets li {
     list-style-type: none;
     padding: 0;
     margin: 16px 0;
@@ -188,6 +192,21 @@ main {
 
 footer {
     flex-shrink: 0;
+}
+
+:root {
+    --certs-div-padding-left: 0;
+}
+
+@media (min-width: 992px) {
+    :root {
+        --certs-div-padding-left: 16px;
+    }
+}
+
+footer .certs>div {
+    margin: 30px 0 0;
+    padding-left: var(--certs-div-padding-left);
 }
 
 footer .heading {


### PR DESCRIPTION
Closes #36 

This PR refactors our layouts to use Bootstrap and tries to maintain the same net effect in terms of styling and spacing.

Note that the attempt to maintain styling/spacing is approximate due to time and lack of necessity -- this means there are some minor discrepancies between what's live on compiler.la vs. this branch. Since we'll be implementing more re-designs (#33), I think this is acceptable. The biggest discrepancy is just on the responsive behavior of the homepage buttons (which I think is ok):

![image](https://user-images.githubusercontent.com/25497886/218193609-85bc6a04-7b4f-4c4f-8820-621c5b8edfcc.png)

This should be ok to merge in whenever approved -- let me know if you notice any unexpected regression!