### PR TITLE
Feat: explicit open/close dates for jobs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,24 +1,23 @@
 {
-    "name": "compiler.la",
-    "dockerComposeFile": "docker-compose.yaml",
-    "service": "site",
-	"workspaceFolder": "/srv/jekyll",
-    "postAttachCommand": [
-        "/bin/bash",
-        ".devcontainer/postAttach.sh"
-      ],
-    "settings": {
-        "terminal.integrated.defaultProfile.linux": "bash",
-        "terminal.integrated.profiles.linux": {
-            "bash": {
-                "path": "/bin/bash"
-            }
-        }
-    },
-    "extensions": [
-		"eamodio.gitlens",
-		"mhutchie.git-graph",
-		"redhat.vscode-xml",
-        "sissel.shopify-liquid"
-	]
+  "name": "compiler.la",
+  "dockerComposeFile": "docker-compose.yaml",
+  "service": "site",
+  "workspaceFolder": "/srv/jekyll",
+  "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
+  "settings": {
+    "terminal.integrated.defaultProfile.linux": "bash",
+    "terminal.integrated.profiles.linux": {
+      "bash": {
+        "path": "/bin/bash"
+      }
+    }
+  },
+  "extensions": [
+    "eamodio.gitlens",
+    "esbenp.prettier-vscode",
+    "mhutchie.git-graph",
+    "redhat.vscode-xml",
+    "sissel.shopify-liquid",
+    ""
+  ]
 }

--- a/_includes/job-apply-button.html
+++ b/_includes/job-apply-button.html
@@ -1,6 +1,0 @@
-{% if page.open %}
-<a class="d-inline-block monospace primary-btn" href="{{ include.link }}">Apply Now</a>
-{% else %}
-<a class="d-inline-block monospace primary-btn btn disabled" href="{{ include.link }}" role="button"
-    aria-disabled="true">Apply Now</a>
-{% endif %}

--- a/_includes/job-json.html
+++ b/_includes/job-json.html
@@ -1,5 +1,8 @@
+{% comment %}
+<!-- prettier-ignore -->
+{% endcomment %}
 {%- if include.job -%}
-{ title:"{{ job.title }}", open_date:"{{ job.open_date }}", close_date:"{{ job.close_date }}", url:"{{ job.url }}" }
+{ title:"{{ include.job.title }}", open_date:"{{ include.job.open_date }}", close_date:"{{ include.job.close_date }}", url:"{{ include.job.url }}" }
 {%- else -%}
 [
     {% for job in site.jobs -%}

--- a/_includes/job-json.html
+++ b/_includes/job-json.html
@@ -1,0 +1,9 @@
+{%- if include.job -%}
+{ title:"{{ job.title }}", open_date:"{{ job.open_date }}", close_date:"{{ job.close_date }}", url:"{{ job.url }}" }
+{%- else -%}
+[
+    {% for job in site.jobs -%}
+    { title:"{{ job.title }}", open_date:"{{ job.open_date }}", close_date:"{{ job.close_date }}", url:"{{ job.url }}" },
+    {% endfor %}
+]
+{%- endif -%}

--- a/_jobs/associate-consultant-scheduling-coordinator.md
+++ b/_jobs/associate-consultant-scheduling-coordinator.md
@@ -4,6 +4,7 @@ title: Associate Consultant, Scheduling Coordinator
 open_date: 2022-05-01
 close_date: 2022-05-13
 ---
+
 **About Compiler:** Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 
 Our team specializes in building software applications around data for operations support and performance management including: data standards development, data engineering, data cleaning, extract transform and load (ETL) workflows, custom application programming interface (API) development and integration, data integration, data pipelines, data analytics, and data science. Our team’s subject matter expertise in transportation, housing, and homelessness provides depth and quality to the services we design and the applications we build.
@@ -18,36 +19,36 @@ This is a 6-month part-time contract position.
 
 ## Responsibilities
 
-+ Data Assessment Support and Scheduling (50%)
-+ Coordinate with Cal-ITP colleagues, Caltrans staff, and representatives from various California transit agencies to schedule virtual meetings on an established schedule using Outlook email and calendar
-+ Ensure meeting participation by following up with attendees, confirming availability, and rescheduling as needed
-+ Manage all videoconferencing and phone requirements
-+ Liaise with internal and external meeting participants to share agendas, notes, and other meeting materials in a timely manner
-+ Monitor group inbox for emails and route to the appropriate team member for response
-+ Payments Support and Scheduling (50%)
-+ Support email inquiries from new customers by sharing informational material via email
-+ Coordinate with new customers to schedule introductory meetings with members of the Cal-ITP Payments team
-+ Support interactions with transit agency representatives by fielding email inquiries and routing them to the appropriate contact within Cal-ITP as needed
-+ Ensure that new customer inquiries are responded to in a timely manner by the correct Payments team member
-+ Track interactions with customers in a CRM and ticketing tool
+- Data Assessment Support and Scheduling (50%)
+- Coordinate with Cal-ITP colleagues, Caltrans staff, and representatives from various California transit agencies to schedule virtual meetings on an established schedule using Outlook email and calendar
+- Ensure meeting participation by following up with attendees, confirming availability, and rescheduling as needed
+- Manage all videoconferencing and phone requirements
+- Liaise with internal and external meeting participants to share agendas, notes, and other meeting materials in a timely manner
+- Monitor group inbox for emails and route to the appropriate team member for response
+- Payments Support and Scheduling (50%)
+- Support email inquiries from new customers by sharing informational material via email
+- Coordinate with new customers to schedule introductory meetings with members of the Cal-ITP Payments team
+- Support interactions with transit agency representatives by fielding email inquiries and routing them to the appropriate contact within Cal-ITP as needed
+- Ensure that new customer inquiries are responded to in a timely manner by the correct Payments team member
+- Track interactions with customers in a CRM and ticketing tool
 
 ## Preferred Qualifications
 
-+ Experience coordinating meetings across multiple calendaring platforms
-+ Proficient in Google Suite, Outlook, and calendaring tools (Doodle, Calend.ly)
-+ Comfortable following up with internal and external contacts, encouraging accountability from meeting participants
-+ Willingness to learn and adapt to new productivity tools and applications (Asana, ClickUp, Airtable, Hubspot, Teamwork, etc.)
-+ Experience with CRMs a plus
-+ Interest in public transportation a plus
+- Experience coordinating meetings across multiple calendaring platforms
+- Proficient in Google Suite, Outlook, and calendaring tools (Doodle, Calend.ly)
+- Comfortable following up with internal and external contacts, encouraging accountability from meeting participants
+- Willingness to learn and adapt to new productivity tools and applications (Asana, ClickUp, Airtable, Hubspot, Teamwork, etc.)
+- Experience with CRMs a plus
+- Interest in public transportation a plus
 
 ## Timeline & Compensation
 
-+ Q2 2022 start date
-+ Hourly compensation
-+ 20 hours per week (Part-time)
-+ Contract position, 6-month term
-+ Possibility that opportunity could expand in the future
-+ Applicant will need to provide their own laptop computer
+- Q2 2022 start date
+- Hourly compensation
+- 20 hours per week (Part-time)
+- Contract position, 6-month term
+- Possibility that opportunity could expand in the future
+- Applicant will need to provide their own laptop computer
 
 ## Location
 
@@ -55,5 +56,5 @@ This is a 6-month part-time contract position.
 
 ## To Apply
 
-+ Send resume, brief intro email and preferences for working (hours, time zone, etc) to [careers@compiler.la](mailto:careers@compiler.la) by May 13, 2022
-+ Cover letters are not expected and extra weight in scoring will not be given to those that include them them
+- Send resume, brief intro email and preferences for working (hours, time zone, etc) to [careers@compiler.la](mailto:careers@compiler.la) by May 13, 2022
+- Cover letters are not expected and extra weight in scoring will not be given to those that include them them

--- a/_jobs/associate-consultant-scheduling-coordinator.md
+++ b/_jobs/associate-consultant-scheduling-coordinator.md
@@ -1,6 +1,8 @@
 ---
 layout: job_post
 title: Associate Consultant, Scheduling Coordinator
+open_date: 2022-05-01
+close_date: 2022-05-13
 ---
 **About Compiler:** Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 

--- a/_jobs/creative-project-manager.md
+++ b/_jobs/creative-project-manager.md
@@ -1,6 +1,8 @@
 ---
 layout: job_post
 title: Creative Services Project Manager - consultant
+open_date: 2021-05-01
+close_date: 2021-05-15
 ---
 The Creative Services Project Manager provides general operational support for all Communication and Content initiatives at [California Integrated Travel Project (Cal-ITP)](https://www.calitp.org/). Responsibilities include management of production timelines for all content and external messaging produced by Cal-ITP, oversight of branded materials and Cal-ITP brand identity, and ownership of the Caltrans Mobility Newsletter.
 

--- a/_jobs/creative-project-manager.md
+++ b/_jobs/creative-project-manager.md
@@ -4,6 +4,7 @@ title: Creative Services Project Manager - consultant
 open_date: 2021-05-01
 close_date: 2021-05-15
 ---
+
 The Creative Services Project Manager provides general operational support for all Communication and Content initiatives at [California Integrated Travel Project (Cal-ITP)](https://www.calitp.org/). Responsibilities include management of production timelines for all content and external messaging produced by Cal-ITP, oversight of branded materials and Cal-ITP brand identity, and ownership of the Caltrans Mobility Newsletter.
 
 This is a six month part-time contract position, contractor will be responsible for assisting formalization of these projects as programs and handoff to full-time program staff in the Fall.
@@ -12,40 +13,43 @@ This is a six month part-time contract position, contractor will be responsible 
 
 Caltrans Mobility Newsletter
 
-+ Manage biweekly meetings with Caltrans to review newsletter content and take requests for newsletter topics. Circulate notes and action items after each meeting.
-+ Organize the review and approval process for the biweekly newsletter, ensuring content has been appropriately edited and reviewed before publication.
-+ Write the email message that accompanies each newsletter. Attend weekly Data and/or Payments meetings and weekly meetings with Program Manager to ensure that relevant project updates are included. Proactively include relevant content in email messaging.
-+ Send newsletter via Constant Contact every two weeks and actively manage the distribution list.
-+ Upload final newsletter PDF to the Wordpress site when ready to publish. Manage archive of past newsletters and email on team shared file server.
+- Manage biweekly meetings with Caltrans to review newsletter content and take requests for newsletter topics. Circulate notes and action items after each meeting.
+- Organize the review and approval process for the biweekly newsletter, ensuring content has been appropriately edited and reviewed before publication.
+- Write the email message that accompanies each newsletter. Attend weekly Data and/or Payments meetings and weekly meetings with Program Manager to ensure that relevant project updates are included. Proactively include relevant content in email messaging.
+- Send newsletter via Constant Contact every two weeks and actively manage the distribution list.
+- Upload final newsletter PDF to the Wordpress site when ready to publish. Manage archive of past newsletters and email on team shared file server.
 
 Communication and Content Production
-+ Track production of all content in production and communication support requests. Meet weekly with Comms and Content team to document status and ensure timely delivery of final drafts.
-+ Keep all content, draft and final, organized in the appropriate shared folders. Ensure that all appropriate content is added to the Cal-ITP Resource Library as appropriate, and notify team when new resources are available.
-+ Maintain Brand Guidelines document and Branded Resources folder. Coordinate all requests for updates to branded material, including new sub-brand logo design.
-+ Identify new opportunities for Comms and Content team to support teams with external messaging by staying on top of internal project timelines and priorities and external comms opportunities.
-+ Manage DOT website pages associated with Cal-ITP, including organization of existing content and publication of new content suitable for the Caltrans website. Obtain Site Core training to be able to self-publish according to Caltrans requirements.
-+ Perform other ad hoc project management duties as needed to support any external communication initiatives.
+
+- Track production of all content in production and communication support requests. Meet weekly with Comms and Content team to document status and ensure timely delivery of final drafts.
+- Keep all content, draft and final, organized in the appropriate shared folders. Ensure that all appropriate content is added to the Cal-ITP Resource Library as appropriate, and notify team when new resources are available.
+- Maintain Brand Guidelines document and Branded Resources folder. Coordinate all requests for updates to branded material, including new sub-brand logo design.
+- Identify new opportunities for Comms and Content team to support teams with external messaging by staying on top of internal project timelines and priorities and external comms opportunities.
+- Manage DOT website pages associated with Cal-ITP, including organization of existing content and publication of new content suitable for the Caltrans website. Obtain Site Core training to be able to self-publish according to Caltrans requirements.
+- Perform other ad hoc project management duties as needed to support any external communication initiatives.
 
 Technology Peer Working Group Coordination
-+ Coordinate quarterly and monthly Peer Working Groups in partnership with Comms and Content and Data Teams. Own all aspects of coordination related to scheduling, coordinating videoconference details, maintaining contact lists, documenting meeting topics and notes on the shared file server, and identifying opportunities for increasing participation from transit operator staff.
-+ Maintain list of discussion/presentation topics suggested internally and by external participants.
-+ Ensure that all meeting participants are aware of their responsibilities for each session and that all meeting agendas and materials are appropriately prepared and circulated
+
+- Coordinate quarterly and monthly Peer Working Groups in partnership with Comms and Content and Data Teams. Own all aspects of coordination related to scheduling, coordinating videoconference details, maintaining contact lists, documenting meeting topics and notes on the shared file server, and identifying opportunities for increasing participation from transit operator staff.
+- Maintain list of discussion/presentation topics suggested internally and by external participants.
+- Ensure that all meeting participants are aware of their responsibilities for each session and that all meeting agendas and materials are appropriately prepared and circulated
 
 Support of Outreach Team
-+ Provide ad hoc operational support for the broader Outreach Team as needed (includes Customer Support, Comms and Content, and Stakeholder Management)
-+ Coordinate regular Outreach Team meetings, including collecting agenda items and scheduling, to ensure that the broader team is aligned and aware of each other’s work.
-+ Send out Teamwork updates as needed sharing Outreach updates
-+ Work with Program Management to ensure that resourcing gaps are addressed
-+ Maintain Outreach calendar in Teamwork and proactively add external comms opportunities.
-+ Maintain documentation of all communications channels and audiences relevant to Cal-ITP external comms.
+
+- Provide ad hoc operational support for the broader Outreach Team as needed (includes Customer Support, Comms and Content, and Stakeholder Management)
+- Coordinate regular Outreach Team meetings, including collecting agenda items and scheduling, to ensure that the broader team is aligned and aware of each other’s work.
+- Send out Teamwork updates as needed sharing Outreach updates
+- Work with Program Management to ensure that resourcing gaps are addressed
+- Maintain Outreach calendar in Teamwork and proactively add external comms opportunities.
+- Maintain documentation of all communications channels and audiences relevant to Cal-ITP external comms.
 
 ## Timeline & Compensation
 
-+ Hourly compensation
-+ 20-30 hours per week (Part-time)
-+ June 1st - November 30th 2021
-+ Contract position
+- Hourly compensation
+- 20-30 hours per week (Part-time)
+- June 1st - November 30th 2021
+- Contract position
 
 ## To Apply
 
-+ Send resume, brief intro and preferences for working (hours, time zone, etc) to Jeremy Dalton (jeremy@method.city) by 5pm PST Friday May 15th 2021.
+- Send resume, brief intro and preferences for working (hours, time zone, etc) to Jeremy Dalton (jeremy@method.city) by 5pm PST Friday May 15th 2021.

--- a/_jobs/customer-success-account-manager.md
+++ b/_jobs/customer-success-account-manager.md
@@ -3,6 +3,7 @@ layout: job_post
 title: Associate Consultant, Customer Success Account Manager
 open_date: 2023-05-05
 close_date: 2023-05-19
+apply_link: https://forms.clickup.com/8631512/f/87d6r-6640/V5BBPCBTCXDAB3S7O4
 ---
 
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
@@ -79,5 +80,3 @@ This is a full-time, salaried position (W-2) with benefits. Full-time employment
 - Applications accepted May 5, 2023 - May 19, 2023
 - Using the linked form, please briefly introduce yourself and upload your resume
 - Cover letters are not expected, and extra weight in scoring will not be given to those that include them
-
-{% include job-apply-button.html link="https://forms.clickup.com/8631512/f/87d6r-6640/V5BBPCBTCXDAB3S7O4" %}

--- a/_jobs/customer-success-account-manager.md
+++ b/_jobs/customer-success-account-manager.md
@@ -4,6 +4,7 @@ title: Associate Consultant, Customer Success Account Manager
 open_date: 2023-05-05
 close_date: 2023-05-19
 ---
+
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 
 Our team specializes in building software applications around data for operations support and performance management including: data standards development, data engineering, data cleaning, extract transform and load (ETL) workflows, custom application programming interface (API) development and integration, data integration, data pipelines, data analytics, and data science. Our team’s subject matter expertise in transportation, housing, and homelessness provides depth and quality to the services we design and the applications we build.
@@ -13,6 +14,7 @@ Our clients have included: City of Los Angeles, City of West Hollywood, CicLAvia
 **About Cal-ITP**: Supported by the California State Transportation Agency (CalSTA) and the California Department of Transportation (Caltrans) through a grant from the California Transit and Intercity Rail Capital Program (TIRCP), the [California Integrated Travel Project (Cal-ITP)](https://www.calitp.org/) is a statewide solution to make travel simpler and cost-effective for everyone. Review our [2021 Accomplishments report](https://www.calitp.org/assets/Cal-ITP.2021.Accomplishments.Report.pdf) to learn more about our work.
 
 ## Role
+
 The Customer Success team helps transit agencies take advantage of the various services offered by Cal-ITP. As an account manager, you will moderate and manage communication between Cal-ITP and the California transit agency customers assigned to you. You will be responsible for maintaining positive and supportive relationships with your assigned agencies and for identifying new opportunities to increase the quality of support provided by Cal-ITP.
 
 You will also be expected to document interactions and agency information in our Customer Relationship Management (CRM) system and to maintain a high-level understanding of Cal-ITP’s various programs and how your agencies are engaging with them.
@@ -22,6 +24,7 @@ This role is client-facing. You’ll report to Anthony Rollins, and collaborate 
 This is a full-time, salaried position (W-2) with benefits. Full-time employment at Compiler is thirty (30) hours per week.
 
 ## Responsibilities
+
 - **Proactive Customer Engagement** You will be responsible for an assigned list of agencies and will be expected to own all communication with those agencies. Activities will include leading scripted introductory calls for newly engaged agencies, hosting an annual review with each agency via Zoom, conducting regular outreach via email regarding new Cal-ITP opportunities or services, and coordinating with other departments within Cal-ITP or Caltrans to streamline additional interactions with your agencies. You will receive training materials and support from teammates to guide you through these interactions. You will maintain documentation of all interactions in the CRM system. As Cal-ITP’s engagement with agencies evolves, you may be asked to provide support to additional agency customers or ad hoc support to agencies without an assigned account manager.
 
 - **Reactive Customer Engagement** You will field all incoming inquiries from the agencies assigned to you, as well as general inquiries or questions from transit agencies without an assigned account manager. This may include communication via email, the CRM, or video conference. You will be expected to develop a general understanding of all current Cal-ITP products and services, as well as an ability to confidently triage and route tickets to the appropriate technical specialist on the Cal-ITP team. You should be comfortable engaging with colleagues and technical specialists to get the appropriate answers to your customers’ questions. You may be asked to attend or moderate virtual meetings with technical specialists. You will document all interactions in the CRM.
@@ -29,6 +32,7 @@ This is a full-time, salaried position (W-2) with benefits. Full-time employment
 - **Building the Customer Success Program at Cal-ITP** You will be an active participant in developing and improving the Customer Success program at Cal-ITP. You will provide input on the strengths and challenges of the current program, collect feedback from the agencies you work with to share internally, and participate in efforts to improve and document Cal-ITP’s approach to customer success. You should be comfortable raising issues you’ve seen your agencies face and participating in identifying scalable solutions to those problems.
 
 ## Required Qualifications
+
 - Experience in an account management or customer service setting
 - Experience with a CRM
 - An ability to engage with customers beyond your assigned list of duties and identify opportunities to increase customer satisfaction
@@ -37,6 +41,7 @@ This is a full-time, salaried position (W-2) with benefits. Full-time employment
 - A personal and professional commitment to bringing anti-racist principles to your work
 
 ## Preferred Qualifications
+
 - Proficiency in Google Workspace
 - Comfortable following up with internal and external contacts, encouraging accountability from customers and colleagues
 - Willingness to learn and adapt to new productivity tools and applications (GitHub, ClickUp, Hubspot, etc.)
@@ -46,12 +51,15 @@ This is a full-time, salaried position (W-2) with benefits. Full-time employment
 - A love of public transit
 
 ## Education
+
 - Per company policy, this position has no formal educational requirements
 
 ## Start Date
+
 - Late June - July 2023
 
 ## Compensation
+
 - $70,000 annually based on qualifications and experience
 - Paid time off: fifteen (15) days paid time off (PTO) and ten (10) sick days annually, federal holidays, and annual holiday closure between December 23 and January 1
 - 100% company-paid medical, dental, and vision insurance premiums for employees; 50% company-paid insurance premiums for employees’ dependents
@@ -61,17 +69,15 @@ This is a full-time, salaried position (W-2) with benefits. Full-time employment
 - Company-provided laptop
 
 ## Location and Work Hours
+
 - This position is remote
 - Los Angeles-based staff have the opportunity to work from our office at the Los Angeles Cleantech Incubator (LACI) / LaKretz Innovation Campus in downtown Los Angeles, CA
 - Flexible working hours; expect an overlap with Pacific Time. The current team is spread across Pacific and Eastern time zones in the US
 
 ## To Apply
+
 - Applications accepted May 5, 2023 - May 19, 2023
 - Using the linked form, please briefly introduce yourself and upload your resume
 - Cover letters are not expected, and extra weight in scoring will not be given to those that include them
 
 {% include job-apply-button.html link="https://forms.clickup.com/8631512/f/87d6r-6640/V5BBPCBTCXDAB3S7O4" %}
-
-_In keeping with our beliefs and goals, no employee or applicant will face discrimination or harassment based on race, color, ancestry, national origin, religion, education, age, gender identity, sexual orientation, marital domestic partner status, familial status, disability status, or veteran status._
-
-_We will consider for employment qualified applicants with arrest and conviction records. [#banthebox](https://bantheboxcampaign.org)_

--- a/_jobs/customer-success-account-manager.md
+++ b/_jobs/customer-success-account-manager.md
@@ -1,7 +1,8 @@
 ---
 layout: job_post
 title: Associate Consultant, Customer Success Account Manager
-open: false
+open_date: 2023-05-05
+close_date: 2023-05-19
 ---
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 

--- a/_jobs/executive-assistant.md
+++ b/_jobs/executive-assistant.md
@@ -17,67 +17,62 @@ This role is internal and not client-facing. You’ll report directly to founder
 
 This is a full-time, salaried position (W2) with benefits. Full-time employment at Compiler is thirty (30) hours per week.
 
-
 ## Responsibilities
 
-* Write proposal materials. You will be responsible for writing accurate and concise bids, often 6 to 20 pages, yourself. You will be writing about software development, data engineering, public policy, open source licensing, and public transportation. Compiler teammates will assist you in learning about these issues. You will engage team members to get the proper information, and be responsible for ultimately writing the bids in the proper format. You’ll be responsible for maintaining versions of standard narrative components, for example a description of company history or our commitment to equity. Government contracting is complicated and requires long-form narrative descriptions of our company, our prior work experiences, our qualifications or certifications, our approach to new work and more. You will also help team members keep updated resumes on file.
+- Write proposal materials. You will be responsible for writing accurate and concise bids, often 6 to 20 pages, yourself. You will be writing about software development, data engineering, public policy, open source licensing, and public transportation. Compiler teammates will assist you in learning about these issues. You will engage team members to get the proper information, and be responsible for ultimately writing the bids in the proper format. You’ll be responsible for maintaining versions of standard narrative components, for example a description of company history or our commitment to equity. Government contracting is complicated and requires long-form narrative descriptions of our company, our prior work experiences, our qualifications or certifications, our approach to new work and more. You will also help team members keep updated resumes on file.
 
-* Project manage bids. In addition to the written contents, contract proposals have complex and detailed requirements – like copies of proof of insurance or signed affidavits of compliance with laws. You’ll create checklists, fill our compliance forms, help staff meet their deadlines, ensure our response package meets all requirements, and lastly organize for signatures and submission. As necessary, you’ll organize meetings, agendas, and notes. This work will occasionally require you to be in the office to print or scan documents.
+- Project manage bids. In addition to the written contents, contract proposals have complex and detailed requirements – like copies of proof of insurance or signed affidavits of compliance with laws. You’ll create checklists, fill our compliance forms, help staff meet their deadlines, ensure our response package meets all requirements, and lastly organize for signatures and submission. As necessary, you’ll organize meetings, agendas, and notes. This work will occasionally require you to be in the office to print or scan documents.
 
-* Triage executive and shared inboxes. As a small firm, we get a lot of important emails and junk email to a few shared inboxes. You’ll filter and triage these messages creating tasks and handing them off to the appropriate staff. You’ll collaborate with other team members to design and implement automations when appropriate. Our team seeks to move work out of email as much as possible into chat and tasks.
+- Triage executive and shared inboxes. As a small firm, we get a lot of important emails and junk email to a few shared inboxes. You’ll filter and triage these messages creating tasks and handing them off to the appropriate staff. You’ll collaborate with other team members to design and implement automations when appropriate. Our team seeks to move work out of email as much as possible into chat and tasks.
 
-* Promote and support conference attendance. You will research and track conference opportunities, and with the team to prioritize conferences Compiler should have a presence at and/or that help individual team members meet professional development goals. As needed, you will assist team members in selecting conferences to attend, submitting budget requests, and booking travel.
+- Promote and support conference attendance. You will research and track conference opportunities, and with the team to prioritize conferences Compiler should have a presence at and/or that help individual team members meet professional development goals. As needed, you will assist team members in selecting conferences to attend, submitting budget requests, and booking travel.
 
 ## Required Qualifications
 
-* Experience with grant writing or similar technical project writing
-* Ability to work independently and self-direct towards goals not tasks
-* A personal and professional commitment to bring anti-racist principles to your work
+- Experience with grant writing or similar technical project writing
+- Ability to work independently and self-direct towards goals not tasks
+- A personal and professional commitment to bring anti-racist principles to your work
 
 ## Preferred Qualifications
 
-* Proficient in Google Suite, Outlook, and calendaring tools (Doodle, Calend.ly, etc.)
-* Comfortable following up with internal and external contacts, encouraging accountability from meeting participants
-* Willingness to learn and adapt to new productivity tools and applications (Lastpass, ClickUp, Copper, Zapier, etc.)
-* Experience with CRMs a plus
-* Experience working with or in proximity to government
-* A love of public transit
+- Proficient in Google Suite, Outlook, and calendaring tools (Doodle, Calend.ly, etc.)
+- Comfortable following up with internal and external contacts, encouraging accountability from meeting participants
+- Willingness to learn and adapt to new productivity tools and applications (Lastpass, ClickUp, Copper, Zapier, etc.)
+- Experience with CRMs a plus
+- Experience working with or in proximity to government
+- A love of public transit
 
 ## Education
 
-* Per company policy, this position has no formal educational requirements
+- Per company policy, this position has no formal educational requirements
 
 ## Start Date
 
-* Mid-February 2023
+- Mid-February 2023
 
 ## Compensation
 
-* $65,000 annually based on qualifications and experience
-* Paid time off: fifteen (15) days paid time off (PTO) and ten (10) sick days annually, federal holidays, and annual holiday closure between December 23 and January 1
-* 100% company-paid medical, dental, and vision insurance premiums for employees; 50% company-paid insurance premiums for employees’ dependents
-* 100% company-paid short- and long-term disability insurance
-* Discretionary budget for home office and/or professional development
-* 401k contribution
-* Company-provided laptop
-* Co-working pass for office in downtown Los Angeles
+- $65,000 annually based on qualifications and experience
+- Paid time off: fifteen (15) days paid time off (PTO) and ten (10) sick days annually, federal holidays, and annual holiday closure between December 23 and January 1
+- 100% company-paid medical, dental, and vision insurance premiums for employees; 50% company-paid insurance premiums for employees’ dependents
+- 100% company-paid short- and long-term disability insurance
+- Discretionary budget for home office and/or professional development
+- 401k contribution
+- Company-provided laptop
+- Co-working pass for office in downtown Los Angeles
 
 ## Location and Work Hours
 
-* Applicants must be residents of Los Angeles County
-* Remote work is okay, but some time in the downtown LA office is required; Compiler is a member of the Los Angeles Cleantech Incubator (LACI) / LaKretz Innovation Campus in downtown Los Angeles, CA
-* The office is a few blocks from the new Metro Little Tokyo / Arts District station that’s expected to open in February 2023. There’s also a Metro Bike Share station on our block.
-* Flexible working hours; expect an overlap with Pacific Time. The current team is spread across Pacific and Eastern time zones in the US.
+- Applicants must be residents of Los Angeles County
+- Remote work is okay, but some time in the downtown LA office is required; Compiler is a member of the Los Angeles Cleantech Incubator (LACI) / LaKretz Innovation Campus in downtown Los Angeles, CA
+- The office is a few blocks from the new Metro Little Tokyo / Arts District station that’s expected to open in February 2023. There’s also a Metro Bike Share station on our block.
+- Flexible working hours; expect an overlap with Pacific Time. The current team is spread across Pacific and Eastern time zones in the US.
 
 ## To Apply
 
-* Applications accepted December 1st – December 31st
-* Using the linked form below, please provide a brief introduction and upload your resume.
-* Cover letters are not expected and extra weight in scoring will not be given to those that include them
-* Writing samples will be requested as part of second round interviews
+- Applications accepted December 1st – December 31st
+- Using the linked form below, please provide a brief introduction and upload your resume.
+- Cover letters are not expected and extra weight in scoring will not be given to those that include them
+- Writing samples will be requested as part of second round interviews
 
 {% include job-apply-button.html link="https://forms.clickup.com/8631512/f/87d6r-2087/GUOF0LDD4SN58BC27T" %}
-
-
-
-_In keeping with our beliefs and goals, no employee or applicant will face discrimination or harassment based on race, color, ancestry, national origin, religion, education, age, gender identity, sexual orientation, marital domestic partner status, familial status, disability status, or veteran status. We will consider for employment qualified applicants with arrest and conviction records. #banthebox_

--- a/_jobs/executive-assistant.md
+++ b/_jobs/executive-assistant.md
@@ -1,7 +1,8 @@
 ---
 layout: job_post
 title: Executive Assistant Business Development
-open: false
+open_date: 2022-12-02
+close_date: 2023-01-17
 ---
 
 About Compiler: Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.

--- a/_jobs/executive-assistant.md
+++ b/_jobs/executive-assistant.md
@@ -3,6 +3,7 @@ layout: job_post
 title: Executive Assistant Business Development
 open_date: 2022-12-02
 close_date: 2023-01-17
+apply_link: https://forms.clickup.com/8631512/f/87d6r-2087/GUOF0LDD4SN58BC27T
 ---
 
 About Compiler: Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
@@ -74,5 +75,3 @@ This is a full-time, salaried position (W2) with benefits. Full-time employment 
 - Using the linked form below, please provide a brief introduction and upload your resume.
 - Cover letters are not expected and extra weight in scoring will not be given to those that include them
 - Writing samples will be requested as part of second round interviews
-
-{% include job-apply-button.html link="https://forms.clickup.com/8631512/f/87d6r-2087/GUOF0LDD4SN58BC27T" %}

--- a/_jobs/product-manager.md
+++ b/_jobs/product-manager.md
@@ -1,7 +1,8 @@
 ---
 layout: job_post
 title: Senior Consultant, Product Manager
-open: false
+open_date: 2023-02-27
+close_date: 2023-03-12
 ---
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 

--- a/_jobs/product-manager.md
+++ b/_jobs/product-manager.md
@@ -3,6 +3,7 @@ layout: job_post
 title: Senior Consultant, Product Manager
 open_date: 2023-02-27
 close_date: 2023-03-12
+apply_link: https://forms.clickup.com/8631512/f/87d6r-5540/DC9U9PVDM86KIWN5XU
 ---
 
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
@@ -76,5 +77,3 @@ Per company policy, this position has no formal educational requirements
 - Applications accepted Monday February 27th - Sunday March 12th 2023
 - Using the linked form, please provide a brief introduction and upload your resume.
 - Cover letters are not expected and extra weight in scoring will not be given to those that include them
-
-{% include job-apply-button.html link="https://forms.clickup.com/8631512/f/87d6r-5540/DC9U9PVDM86KIWN5XU" %}

--- a/_jobs/product-manager.md
+++ b/_jobs/product-manager.md
@@ -4,6 +4,7 @@ title: Senior Consultant, Product Manager
 open_date: 2023-02-27
 close_date: 2023-03-12
 ---
+
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 
 Our team specializes in building software applications around data for operations support and performance management including: data standards development, data engineering, data cleaning, extract transform and load (ETL) workflows, custom application programming interface (API) development and integration, data integration, data pipelines, data analytics, and data science. Our team’s subject matter expertise in transportation, housing, and homelessness provides depth and quality to the services we design and the applications we build.
@@ -18,41 +19,38 @@ We are looking for a Product Manager to support the [Cal-ITP Benefits](https://b
 
 This is a contract position, with opportunities for a W2 employment in the future.
 
-
 ## Responsibilities
 
-* Support client in defining and communicating product vision and requirements to stakeholders
-* Scope projects in collaboration with client especially considering sustainability and impact of new product(s)
-* Lead development of product specifications and facilitate buy-in on approaches/solutions to problems with clients and their stakeholders.
-* Coordinate with product, design, and engineering to deliver products and features.
-* Document/ communicate project risks and timelines to team and stakeholders.
-* Manage monthly sprint process, including sprint planning meetings
-* Prepare and share progress reports to stakeholders
-* Work closely with comms and outreach teams to develop strategies to increase impact of product
-* Document product processes to help ensure sustainability of products
-* Define and develop product analytics for product usage
-
+- Support client in defining and communicating product vision and requirements to stakeholders
+- Scope projects in collaboration with client especially considering sustainability and impact of new product(s)
+- Lead development of product specifications and facilitate buy-in on approaches/solutions to problems with clients and their stakeholders.
+- Coordinate with product, design, and engineering to deliver products and features.
+- Document/ communicate project risks and timelines to team and stakeholders.
+- Manage monthly sprint process, including sprint planning meetings
+- Prepare and share progress reports to stakeholders
+- Work closely with comms and outreach teams to develop strategies to increase impact of product
+- Document product processes to help ensure sustainability of products
+- Define and develop product analytics for product usage
 
 ## Required qualifications
 
-* 2+ years working in product management
-* Ability to work independently and self-direct towards goals not tasks
-* Experience managing complex products with multiple stakeholders
-* Experience with task management and/or product management tools
-* A personal and professional commitment to bring anti-racist principles to your work
+- 2+ years working in product management
+- Ability to work independently and self-direct towards goals not tasks
+- Experience managing complex products with multiple stakeholders
+- Experience with task management and/or product management tools
+- A personal and professional commitment to bring anti-racist principles to your work
 
 ## Preferred qualifications
 
-* Experience working as a consultant
-* Experience working with or in proximity to government
-* Experience with and ability to incorporate inclusive and accessible design into processes.
-* Experience with products that handle sensitive data/ personally identifiable data (PII)
-* Demonstrated experience working with data, data literacy.
-* Ability to work independently and self-direct towards goals not tasks
-* Familiarity with digital tools such as; GitHub, Figma, Google Cloud
-* A personal interest in social justice, civic technology, or advocacy is helpful
-* A love of public transportation
-
+- Experience working as a consultant
+- Experience working with or in proximity to government
+- Experience with and ability to incorporate inclusive and accessible design into processes.
+- Experience with products that handle sensitive data/ personally identifiable data (PII)
+- Demonstrated experience working with data, data literacy.
+- Ability to work independently and self-direct towards goals not tasks
+- Familiarity with digital tools such as; GitHub, Figma, Google Cloud
+- A personal interest in social justice, civic technology, or advocacy is helpful
+- A love of public transportation
 
 ## Education
 
@@ -60,27 +58,23 @@ Per company policy, this position has no formal educational requirements
 
 ## Start Date
 
-* Mid to Late April 2023
+- Mid to Late April 2023
 
 ## Compensation
 
-* Hourly compensation, $115/hour
-* Applicant will need to provide their own laptop computer
+- Hourly compensation, $115/hour
+- Applicant will need to provide their own laptop computer
 
 ## Location and Work Hours
 
-* This position is remote.
-* Los Angeles based staff have the opportunity to work from our office at the Los Angeles Cleantech Incubator (LACI) / LaKretz Innovation Campus in downtown Los Angeles, CA
-* Flexible working hours; expect an overlap with Pacific Time. The current team is spread across Pacific and Eastern time zones in the US.
+- This position is remote.
+- Los Angeles based staff have the opportunity to work from our office at the Los Angeles Cleantech Incubator (LACI) / LaKretz Innovation Campus in downtown Los Angeles, CA
+- Flexible working hours; expect an overlap with Pacific Time. The current team is spread across Pacific and Eastern time zones in the US.
 
 ## To Apply
 
-* Applications accepted Monday February 27th - Sunday March 12th 2023
-* Using the linked form, please provide a brief introduction and upload your resume.
-* Cover letters are not expected and extra weight in scoring will not be given to those that include them
+- Applications accepted Monday February 27th - Sunday March 12th 2023
+- Using the linked form, please provide a brief introduction and upload your resume.
+- Cover letters are not expected and extra weight in scoring will not be given to those that include them
 
 {% include job-apply-button.html link="https://forms.clickup.com/8631512/f/87d6r-5540/DC9U9PVDM86KIWN5XU" %}
-
-_In keeping with our beliefs and goals, no employee or applicant will face discrimination or harassment based on race, color, ancestry, national origin, religion, education, age, gender identity, sexual orientation, marital domestic partner status, familial status, disability status, or veteran status._
-
-_We will consider for employment qualified applicants with arrest and conviction records. #banthebox_

--- a/_jobs/software-engineer.md
+++ b/_jobs/software-engineer.md
@@ -1,6 +1,8 @@
 ---
 layout: job_post
 title: Software Engineer - W2
+open_date: 2021-06-01
+close_date: 2021-06-18
 ---
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 

--- a/_jobs/software-engineer.md
+++ b/_jobs/software-engineer.md
@@ -4,6 +4,7 @@ title: Software Engineer - W2
 open_date: 2021-06-01
 close_date: 2021-06-18
 ---
+
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 
 Our team specializes in building software applications around data for operations support and performance management including: data standards development, data engineering, data cleaning, extract transform and load (ETL) workflows, custom application programming interface (API) development and integration, data integration, data pipelines, data analytics, and data science. Our team’s subject matter expertise in transportation, housing, and homelessness provides depth and quality to the services we design and the applications we build.
@@ -14,23 +15,23 @@ We are looking for a Software Engineer to support a range of new and ongoing cli
 
 ## Responsibilities
 
-* Design and build open source software that streamlines the delivery of public services with a focus on equity and active harm reduction
-* Interact with clients to iteratively gather requirements, refine scope, and demo progress
-* Document your work, including asynchronous communications, to inform internal and client teams
-* Coordinate with product, design, and engineering to deliver delightful products and services
-* Pair program, code review, contribute to architecture decisions, help create standard patterns and practices for development and DevOps
-* Self-direct and time-manage across multiple client projects with varying levels of complexity, demand, and constraint
+- Design and build open source software that streamlines the delivery of public services with a focus on equity and active harm reduction
+- Interact with clients to iteratively gather requirements, refine scope, and demo progress
+- Document your work, including asynchronous communications, to inform internal and client teams
+- Coordinate with product, design, and engineering to deliver delightful products and services
+- Pair program, code review, contribute to architecture decisions, help create standard patterns and practices for development and DevOps
+- Self-direct and time-manage across multiple client projects with varying levels of complexity, demand, and constraint
 
 ## Preferred qualifications
 
-* Experience working with or in proximity to government
-* Experience using modern, high-level programming languages such as Python and JavaScript to build web applications, API services, or similar
-* Experience using Docker and containers to manage reproducible environments
-* Experience deploying production applications and services to cloud environments such as AWS and GCP
-* Experience collaborating with product managers and remote teams
-* Knowledge of Git / GitHub based development workflows and open source project management
-* A love of public transportation
-* A personal and professional commitment to bring anti-racist principles into development practices
+- Experience working with or in proximity to government
+- Experience using modern, high-level programming languages such as Python and JavaScript to build web applications, API services, or similar
+- Experience using Docker and containers to manage reproducible environments
+- Experience deploying production applications and services to cloud environments such as AWS and GCP
+- Experience collaborating with product managers and remote teams
+- Knowledge of Git / GitHub based development workflows and open source project management
+- A love of public transportation
+- A personal and professional commitment to bring anti-racist principles into development practices
 
 ## Position type
 
@@ -57,7 +58,3 @@ Remote work is expected and hours are flexible. QTPOC applicants are welcome. To
 Applications will be accepted until Friday, June 18th, 2021.
 
 All applicants will receive an acknowledgement that their application has been received within 24 hours of successful submission. Those candidates selected for further consideration will be contacted to schedule an interview for the week of June 21st, 2021.
-
-_In keeping with our beliefs and goals, no employee or applicant will face discrimination or harassment based on race, color, ancestry, national origin, religion, education, age, gender identity, sexual orientation, marital domestic partner status, familial status, disability status, or veteran status._
-
-_We will consider for employment qualified applicants with arrest and conviction records. #banthebox_

--- a/_jobs/ux-ui-designer-researcher.md
+++ b/_jobs/ux-ui-designer-researcher.md
@@ -1,7 +1,8 @@
 ---
 layout: job_post
 title: Senior Consultant, UX/UI Designer and Researcher
-open: false
+open_date: 2022-06-22
+close_date: 2022-07-01
 ---
 **About Compiler:** Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 

--- a/_jobs/ux-ui-designer-researcher.md
+++ b/_jobs/ux-ui-designer-researcher.md
@@ -4,6 +4,7 @@ title: Senior Consultant, UX/UI Designer and Researcher
 open_date: 2022-06-22
 close_date: 2022-07-01
 ---
+
 **About Compiler:** Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 
 Our team specializes in building software applications around data for operations support and performance management including: data standards development, data engineering, data cleaning, extract transform and load (ETL) workflows, custom application programming interface (API) development and integration, data integration, data pipelines, data analytics, and data science. Our team’s subject matter expertise in transportation, housing, and homelessness provides depth and quality to the services we design and the applications we build.
@@ -20,40 +21,40 @@ You’ll collaborate with a small team of designers and engineers. You’ll have
 
 ## Responsibilities
 
-+ Identify and select appropriate methodologies for projects
-+ Lead UX Design and Research on products
-+ Lead planning of and/or execute user research and user testing.
-+ Document your work including creating synthesis presentations for asynchronous communications with the team and client after executing user research or user testing efforts
-+ Design and facilitate design workshops with team, stakeholders, and/or clients as needed
-+ Coordinate with external non-profit partners responsible for recruiting users for research and/or testing
-+ Coordinate with admin to get compensation for users processed in a compliant and timely manner
-+ Ensuring that design processes and outputs are both inclusive and accessible
-+ Coordinate with product, design, and engineering to deliver complex products.
+- Identify and select appropriate methodologies for projects
+- Lead UX Design and Research on products
+- Lead planning of and/or execute user research and user testing.
+- Document your work including creating synthesis presentations for asynchronous communications with the team and client after executing user research or user testing efforts
+- Design and facilitate design workshops with team, stakeholders, and/or clients as needed
+- Coordinate with external non-profit partners responsible for recruiting users for research and/or testing
+- Coordinate with admin to get compensation for users processed in a compliant and timely manner
+- Ensuring that design processes and outputs are both inclusive and accessible
+- Coordinate with product, design, and engineering to deliver complex products.
 
 ## Preferred qualifications
 
-+ 2+ years working in UX / UI design
-+ Experience working as a consultant
-+ Experience working with or in proximity to government
-+ Demonstrated experience working with data, data literacy.
-+ Experience in inclusive and accessible design
-+ Ability to work independently and self-direct towards goals not tasks
-+ Experience collaborating with product managers
-+ Familiarity with digital tools such as; GitHub, Figma, Google Cloud.
-+ A love of public transportation
-+ A personal and professional commitment to bring anti-racist principles into design practices.
-+ This position has no formal educational requirements.
+- 2+ years working in UX / UI design
+- Experience working as a consultant
+- Experience working with or in proximity to government
+- Demonstrated experience working with data, data literacy.
+- Experience in inclusive and accessible design
+- Ability to work independently and self-direct towards goals not tasks
+- Experience collaborating with product managers
+- Familiarity with digital tools such as; GitHub, Figma, Google Cloud.
+- A love of public transportation
+- A personal and professional commitment to bring anti-racist principles into design practices.
+- This position has no formal educational requirements.
 
 ## Timeline & Compensation
 
-+ July 2022
-+ 20 hours per week
-+ Contract position.
-+ Hourly compensation at $115/hour
+- July 2022
+- 20 hours per week
+- Contract position.
+- Hourly compensation at $115/hour
 
 ## Location
 
-+ 100% Remote
+- 100% Remote
 
 ## To Apply
 

--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -5,7 +5,15 @@ title_prefix: "Jobs with Compiler:"
 
 <h1>{{ page.title }}</h1>
 
-{{ content }}
+{{ content }} {% if page.apply_link %}
+<a
+  class="d-inline-block monospace primary-btn"
+  id="apply"
+  href="{{ page.apply_link }}"
+>
+  Apply Now
+</a>
+{% endif %}
 
 <p>
   <em>
@@ -33,3 +41,26 @@ title_prefix: "Jobs with Compiler:"
 <div>
   <a class="monospace lg-link" href="/jobs">Back to Jobs</a>
 </div>
+
+<script
+  src="https://cdn.jsdelivr.net/npm/luxon@3.3.0/build/global/luxon.min.js"
+  crossorigin="anonymous"
+></script>
+<script>
+  // override default Timezone for California
+  luxon.Settings.defaultZone = "America/Los_Angeles";
+  const DateTime = luxon.DateTime;
+  const now = DateTime.now();
+
+  const job = {% include job-json.html job=page %};
+  const open_date = DateTime.fromISO(job.open_date).startOf("day");
+  const close_date = DateTime.fromISO(job.close_date).endOf("day");
+
+  if(open_date > now || close_date < now) {
+    const apply = document.getElementById("apply");
+    if (apply) {
+      apply.classList.add("btn", "disabled");
+      apply.setAttribute("aria-disabled", "true");
+    }
+  }
+</script>

--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -2,10 +2,34 @@
 layout: default
 title_prefix: "Jobs with Compiler:"
 ---
+
 <h1>{{ page.title }}</h1>
 
 {{ content }}
 
+<p>
+  <em>
+    In keeping with our beliefs and goals, no employee or applicant will face
+    discrimination or harassment based on race, color, ancestry, national
+    origin, religion, education, age, gender identity, sexual orientation,
+    marital domestic partner status, familial status, disability status, or
+    veteran status.
+  </em>
+</p>
+<p>
+  <em>
+    We will consider for employment qualified applicants with arrest and
+    conviction records.
+    <a
+      href="https://bantheboxcampaign.org"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      #banthebox
+    </a>
+  </em>
+</p>
+
 <div>
-    <a class="monospace lg-link" href="/jobs">Back to Jobs</a>
+  <a class="monospace lg-link" href="/jobs">Back to Jobs</a>
 </div>

--- a/jobs.html
+++ b/jobs.html
@@ -5,7 +5,7 @@ title: Jobs with Compiler
 <h1>Jobs</h1>
 
 <h2>Accepting applications</h2>
-<ul id="open"></ul>
+<ul id="open" class="mx-3"></ul>
 
 <h2>Past opportunities</h2>
 <ul id="closed" class="mx-3"></ul>

--- a/jobs.html
+++ b/jobs.html
@@ -34,16 +34,16 @@ title: Jobs with Compiler
 <script>
     // override default Timezone for California
     luxon.Settings.defaultZone = "America/Los_Angeles";
-    var DateTime = luxon.DateTime;
-    var now = DateTime.now();
+    const DateTime = luxon.DateTime;
+    const now = DateTime.now();
 
-    var all_jobs = {% include job-json.html %};
-    var open_jobs = [];
-    var closed_jobs = [];
+    const all_jobs = {% include job-json.html %};
+    const open_jobs = [];
+    const closed_jobs = [];
 
     all_jobs.forEach(job => {
-        var open_date = DateTime.fromISO(job.open_date).startOf("day");
-        var close_date = DateTime.fromISO(job.close_date).endOf("day");
+        const open_date = DateTime.fromISO(job.open_date).startOf("day");
+        const close_date = DateTime.fromISO(job.close_date).endOf("day");
 
         if(open_date <= now && close_date >= now) {
             open_jobs.push(job);

--- a/jobs.html
+++ b/jobs.html
@@ -5,25 +5,10 @@ title: Jobs with Compiler
 <h1>Jobs</h1>
 
 <h2>Accepting applications</h2>
-{% assign open_jobs = site.jobs | where: "open", "true" %}
-{% if open_jobs.size > 0 %}
-<ul>
-    {% for job in open_jobs %}
-    <li><a href="{{ job.url }}">{{ job.title }}</a></li>
-    {% endfor %}
-</ul>
-{% else %}
-<p>There are no positions accepting applications at the moment.</p>
-{% endif %}
+<ul id="open"></ul>
 
 <h2>Past opportunities</h2>
-<ul class="mx-3">
-    {% for job in site.jobs %}
-    {% if job.open != true %}
-    <li><a href="{{ job.url }}">{{ job.title }}</a></li>
-    {% endif %}
-    {% endfor %}
-</ul>
+<ul id="closed" class="mx-3"></ul>
 
 <p class="mb-5">
     Missed a past opportunity? <a href="http://eepurl.com/h6qTKL">Subscribe</a> to our mailing list, as we are always
@@ -53,9 +38,31 @@ title: Jobs with Compiler
         }
     });
 
-    console.log("Now: " + now.toISO());
-    console.log("Open jobs");
-    console.log(open_jobs);
-    console.log("Closed jobs");
-    console.log(closed_jobs);
+    function createJobItem(job) {
+        const li = document.createElement("li");
+        const a = document.createElement("a");
+        a.append(job.title);
+        a.href = job.url;
+        li.appendChild(a);
+        return li;
+    }
+
+    const open_ul = document.getElementById("open");
+    const closed_ul = document.getElementById("closed");
+
+    open_jobs.forEach(job => {
+        const item = createJobItem(job);
+        open_ul.appendChild(item);
+    });
+
+    closed_jobs.forEach(job => {
+        const item = createJobItem(job);
+        closed_ul.appendChild(item);
+    });
+
+    if (open_jobs.length < 1) {
+        const p = document.createElement("p");
+        p.append("There are no positions accepting applications at the moment.");
+        open_ul.replaceWith(p);
+    }
 </script>

--- a/jobs.html
+++ b/jobs.html
@@ -31,3 +31,31 @@ title: Jobs with Compiler
 </p>
 
 <script src="https://cdn.jsdelivr.net/npm/luxon@3.3.0/build/global/luxon.min.js" crossorigin="anonymous"></script>
+<script>
+    // override default Timezone for California
+    luxon.Settings.defaultZone = "America/Los_Angeles";
+    var DateTime = luxon.DateTime;
+    var now = DateTime.now();
+
+    var all_jobs = {% include job-json.html %};
+    var open_jobs = [];
+    var closed_jobs = [];
+
+    all_jobs.forEach(job => {
+        var open_date = DateTime.fromISO(job.open_date).startOf("day");
+        var close_date = DateTime.fromISO(job.close_date).endOf("day");
+
+        if(open_date <= now && close_date >= now) {
+            open_jobs.push(job);
+        }
+        else {
+            closed_jobs.push(job);
+        }
+    });
+
+    console.log("Now: " + now.toISO());
+    console.log("Open jobs");
+    console.log(open_jobs);
+    console.log("Closed jobs");
+    console.log(closed_jobs);
+</script>

--- a/jobs.html
+++ b/jobs.html
@@ -29,3 +29,5 @@ title: Jobs with Compiler
     Missed a past opportunity? <a href="http://eepurl.com/h6qTKL">Subscribe</a> to our mailing list, as we are always
     looking for great candidates.
 </p>
+
+<script src="https://cdn.jsdelivr.net/npm/luxon@3.3.0/build/global/luxon.min.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
Closes #54 

Closes https://app.clickup.com/t/863gyj9pg

## Confirming date logic works

Running the preview site from UTC+4 shows the correct `America/Los_Angeles` time:

![image](https://github.com/compilerla/compiler.la/assets/1783439/defba2bc-a6b0-429a-9bd8-1e0fa5d6659a)

## Confirming jobs display in the correct list

Added a test job with a current open window:

![image](https://github.com/compilerla/compiler.la/assets/1783439/ef89a427-e9ba-4d44-a43c-1f7cd5e73cdb)

And confirmed it showed up under the "Accepting applications" heading:

![image](https://github.com/compilerla/compiler.la/assets/1783439/7335cab0-320e-42e0-b8e2-7fc845d49705)

## Confirming Apply link for open/closed jobs

The test open job:

![image](https://github.com/compilerla/compiler.la/assets/1783439/a67a6f6e-91ce-4d43-ad41-abe539e1aeb0)

A closed job:

![image](https://github.com/compilerla/compiler.la/assets/1783439/9d28508c-674d-47df-bef5-48e216743b27)