### PR TITLE
Refactor: improvements to job title formatting

### DIFF
--- a/_includes/job-json.html
+++ b/_includes/job-json.html
@@ -2,11 +2,11 @@
 <!-- prettier-ignore -->
 {% endcomment %}
 {%- if include.job -%}
-{ title:"{{ include.job.title }}", open_date:"{{ include.job.open_date }}", close_date:"{{ include.job.close_date }}", url:"{{ include.job.url }}" }
+{ title:"{{ include.job.title }}", type:"{{ include.job.type }}", open_date:"{{ include.job.open_date }}", close_date:"{{ include.job.close_date }}", url:"{{ include.job.url }}" }
 {%- else -%}
 [
     {% for job in site.jobs -%}
-    { title:"{{ job.title }}", open_date:"{{ job.open_date }}", close_date:"{{ job.close_date }}", url:"{{ job.url }}" },
+    { title:"{{ job.title }}", type:"{{ job.type }}", open_date:"{{ job.open_date }}", close_date:"{{ job.close_date }}", url:"{{ job.url }}" },
     {% endfor %}
 ]
 {%- endif -%}

--- a/_includes/job-json.html
+++ b/_includes/job-json.html
@@ -5,7 +5,8 @@
 { title:"{{ include.job.title }}", type:"{{ include.job.type }}", open_date:"{{ include.job.open_date }}", close_date:"{{ include.job.close_date }}", url:"{{ include.job.url }}" }
 {%- else -%}
 [
-    {% for job in site.jobs -%}
+    {% assign sorted_jobs = (site.jobs | sort: "title") %}
+    {% for job in sorted_jobs -%}
     { title:"{{ job.title }}", type:"{{ job.type }}", open_date:"{{ job.open_date }}", close_date:"{{ job.close_date }}", url:"{{ job.url }}" },
     {% endfor %}
 ]

--- a/_jobs/associate-consultant-scheduling-coordinator.md
+++ b/_jobs/associate-consultant-scheduling-coordinator.md
@@ -3,6 +3,7 @@ layout: job_post
 title: Associate Consultant, Scheduling Coordinator
 open_date: 2022-05-01
 close_date: 2022-05-13
+type: Contract
 ---
 
 **About Compiler:** Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.

--- a/_jobs/creative-project-manager.md
+++ b/_jobs/creative-project-manager.md
@@ -1,8 +1,9 @@
 ---
 layout: job_post
-title: Creative Services Project Manager - consultant
+title: Consultant, Creative Services Project Manager
 open_date: 2021-05-01
 close_date: 2021-05-15
+type: Contract
 ---
 
 The Creative Services Project Manager provides general operational support for all Communication and Content initiatives at [California Integrated Travel Project (Cal-ITP)](https://www.calitp.org/). Responsibilities include management of production timelines for all content and external messaging produced by Cal-ITP, oversight of branded materials and Cal-ITP brand identity, and ownership of the Caltrans Mobility Newsletter.

--- a/_jobs/customer-success-account-manager.md
+++ b/_jobs/customer-success-account-manager.md
@@ -4,6 +4,7 @@ title: Associate Consultant, Customer Success Account Manager
 open_date: 2023-05-05
 close_date: 2023-05-19
 apply_link: https://forms.clickup.com/8631512/f/87d6r-6640/V5BBPCBTCXDAB3S7O4
+type: W-2
 ---
 
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.

--- a/_jobs/executive-assistant.md
+++ b/_jobs/executive-assistant.md
@@ -4,6 +4,7 @@ title: Executive Assistant Business Development
 open_date: 2022-12-02
 close_date: 2023-01-17
 apply_link: https://forms.clickup.com/8631512/f/87d6r-2087/GUOF0LDD4SN58BC27T
+type: W-2
 ---
 
 About Compiler: Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.

--- a/_jobs/product-manager.md
+++ b/_jobs/product-manager.md
@@ -4,6 +4,7 @@ title: Senior Consultant, Product Manager
 open_date: 2023-02-27
 close_date: 2023-03-12
 apply_link: https://forms.clickup.com/8631512/f/87d6r-5540/DC9U9PVDM86KIWN5XU
+type: Contract
 ---
 
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.

--- a/_jobs/software-engineer.md
+++ b/_jobs/software-engineer.md
@@ -1,8 +1,9 @@
 ---
 layout: job_post
-title: Software Engineer - W2
+title: Software Engineer
 open_date: 2021-06-01
 close_date: 2021-06-18
+type: W-2
 ---
 
 Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.

--- a/_jobs/ux-ui-designer-researcher.md
+++ b/_jobs/ux-ui-designer-researcher.md
@@ -3,6 +3,7 @@ layout: job_post
 title: Senior Consultant, UX/UI Designer and Researcher
 open_date: 2022-06-22
 close_date: 2022-07-01
+type: Contract
 ---
 
 **About Compiler:** Compiler is a small, woman-owned software consultancy. Compiler helps service-oriented government agencies build open source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.

--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -3,7 +3,7 @@ layout: default
 title_prefix: "Jobs with Compiler:"
 ---
 
-<h1>{{ page.title }}</h1>
+<h1>{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
 
 {{ content }} {% if page.apply_link %}
 <a

--- a/jobs.html
+++ b/jobs.html
@@ -42,6 +42,9 @@ title: Jobs with Compiler
         const li = document.createElement("li");
         const a = document.createElement("a");
         a.append(job.title);
+        if (job.type) {
+            a.append(" (" + job.type + ")");
+        }
         a.href = job.url;
         li.appendChild(a);
         return li;


### PR DESCRIPTION
Part of #82 

Introduces a `type` variable to job post front matter. This is so job titles appear in a more consistent format, which is shown in the Figma screens for #82.

This PR also sorts jobs by title.