### PR TITLE
feat(job-post): add Bootstrap columns, top/bottom margin and padding

### DIFF
--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -3,43 +3,47 @@ layout: default
 title_prefix: "Jobs with Compiler:"
 ---
 
-<h1>{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
+<div class="row">
+  <div class="offset-md-2 col-md-7 col-12 mt-5 pt-5 mb-5 pb-5">
+    <h1 class="mt-4 pt-2">{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
 
-{{ content }} {% if page.apply_link %}
-<a
-  class="d-inline-block monospace primary-btn"
-  id="apply"
-  href="{{ page.apply_link }}"
->
-  Apply Now
-</a>
-{% endif %}
-
-<p>
-  <em>
-    In keeping with our beliefs and goals, no employee or applicant will face
-    discrimination or harassment based on race, color, ancestry, national
-    origin, religion, education, age, gender identity, sexual orientation,
-    marital domestic partner status, familial status, disability status, or
-    veteran status.
-  </em>
-</p>
-<p>
-  <em>
-    We will consider for employment qualified applicants with arrest and
-    conviction records.
+    {{ content }} {% if page.apply_link %}
     <a
-      href="https://bantheboxcampaign.org"
-      target="_blank"
-      rel="noopener noreferrer"
+      class="d-inline-block monospace primary-btn"
+      id="apply"
+      href="{{ page.apply_link }}"
     >
-      #banthebox
+      Apply Now
     </a>
-  </em>
-</p>
+    {% endif %}
 
-<div>
-  <a class="monospace lg-link" href="/jobs">Back to Jobs</a>
+    <p>
+      <em>
+        In keeping with our beliefs and goals, no employee or applicant will face
+        discrimination or harassment based on race, color, ancestry, national
+        origin, religion, education, age, gender identity, sexual orientation,
+        marital domestic partner status, familial status, disability status, or
+        veteran status.
+      </em>
+    </p>
+    <p>
+      <em>
+        We will consider for employment qualified applicants with arrest and
+        conviction records.
+        <a
+          href="https://bantheboxcampaign.org"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          #banthebox
+        </a>
+      </em>
+    </p>
+
+    <div>
+      <a class="monospace lg-link" href="/jobs">Back to Jobs</a>
+    </div>
+  </div>
 </div>
 
 <script


### PR DESCRIPTION
closes #83 

This PR aims to add the correct columns, width, margin/padding so the current Job page is easier to read.

## What this PR does
- Apply margin and padding to the individual Job page for Desktop

## What this PR does not do
- Change H1, H2 styles
- Remove the `Back to Jobs` page (b/c we don't have a Jobs menu link on the page yet)

These will come in subsequent PRs after https://github.com/compilerla/compiler.la/pull/87/ is merged


