### PR TITLE
Typography + Job Posting page margins

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
     </script>
 </head>
 
-<body>
+<body class="{{ layout.classes }}">
     <header>
         <a href="/"><img class="logo" src="/assets/compiler_logo_stacked.svg" alt="Compiler logo"></a>
     </header>

--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -5,17 +5,19 @@ title_prefix: "Jobs with Compiler:"
 ---
 
 <div class="row">
-  <div class="offset-md-2 col-md-7 col-12 mt-5 pt-5 mb-5 pb-5">
-    <h1 class="mt-4 pt-2">{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
+  <div class="offset-md-2 col-md-7 col-12">
+    <h1 class="pb-4 mb-2 pb-md-5 mb-md-3">{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
 
-    {{ content }} {% if page.apply_link %}
-    <a
-      class="d-inline-block monospace primary-btn"
-      id="apply"
-      href="{{ page.apply_link }}"
-    >
-      Apply Now
-    </a>
+    {{ content }}
+
+    {% if page.apply_link %}
+      <a
+        class="d-inline-block monospace primary-btn"
+        id="apply"
+        href="{{ page.apply_link }}"
+      >
+        Apply Now
+      </a>
     {% endif %}
 
     <p>

--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -3,9 +3,13 @@ layout: default
 title_prefix: "Jobs with Compiler:"
 ---
 
+<<<<<<< HEAD
 <div class="row">
   <div class="offset-md-2 col-md-7 col-12 mt-5 pt-5 mb-5 pb-5">
     <h1 class="mt-4 pt-2">{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
+=======
+<h1 class="h2">{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
+>>>>>>> 1ddfd80 (feat(css): first pass at header css)
 
     {{ content }} {% if page.apply_link %}
     <a

--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -4,13 +4,9 @@ classes: posting
 title_prefix: "Jobs with Compiler:"
 ---
 
-<<<<<<< HEAD
 <div class="row">
   <div class="offset-md-2 col-md-7 col-12 mt-5 pt-5 mb-5 pb-5">
     <h1 class="mt-4 pt-2">{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
-=======
-<h1 class="h2">{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
->>>>>>> 1ddfd80 (feat(css): first pass at header css)
 
     {{ content }} {% if page.apply_link %}
     <a

--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+classes: posting
 title_prefix: "Jobs with Compiler:"
 ---
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 description: We build open-source, human-centered, secure, agile solutions to support the delivery of government services that increase equity of opportunity.
 ---
 <div class="row py-5">
-    <h1 class="san-serif">we build software for the government</h1>
+    <h1 class="sans-serif">we build software for the government</h1>
 </div>
 
 <div class="d-flex flex-column flex-lg-row mb-5">

--- a/styles/base.css
+++ b/styles/base.css
@@ -159,10 +159,13 @@ h2,
 }
 
 h3,
-.h3 {
+.h3,
+.posting h2 {
     font-size: var(--h3-font-size);
     font-weight: var(--h3-font-weight);
     line-height: var(--h3-line-height);
+    margin-top: 0;
+    margin-bottom: 1rem;
 }
 
 h4,
@@ -177,6 +180,10 @@ h5,
     font-size: var(--h5-font-size);
     font-weight: var(--h5-font-weight);
     line-height: var(--h5-line-height);
+}
+
+.posting h2 {
+    margin-top: 40px;
 }
 
 /*#endregion */

--- a/styles/base.css
+++ b/styles/base.css
@@ -10,7 +10,7 @@
     --grey: #EDEDED;
     --white: #FFFFFF;
     --bs-font-sans-serif: "Roboto, system-ui,-apple-system,"Segoe UI","Helvetica Neue","Noto Sans","Liberation Sans",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"";
-    --bs-font-monospace: "'Source Code Pro Bold', SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace";
+    --bs-font-monospace: "Source Code Pro Bold",monospace;
 }
 
 * {
@@ -92,11 +92,11 @@ h3,
 .h3,
 h4,
 .h4 {
-    font-family: 'Source Code Pro Bold', 'Courier New', Courier, monospace;
+    font-family: var(--bs-font-monospace);
 }
 
 .sans-serif {
-    font-family: 'Roboto', Arial, Helvetica, sans-serif;
+    font-family: var(--bs-font-sans-serif);
 }
 
 /*#endregion */

--- a/styles/base.css
+++ b/styles/base.css
@@ -351,6 +351,19 @@ footer .address {
 
 /* Job Posting Page */
 
+:root {
+    --posting-margin: 102px 0 96px 0;
+}
+
+@media (min-width: 992px) {
+    :root {
+        --posting-margin: 135px 0 104px 0;
+    }
+}
+.posting main {
+    margin: var(--posting-margin);
+}
+
 .posting h2 {
     margin-top: 40px;
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -9,6 +9,8 @@
     --black: #000000;
     --grey: #EDEDED;
     --white: #FFFFFF;
+    --bs-font-sans-serif: "Roboto, system-ui,-apple-system,"Segoe UI","Helvetica Neue","Noto Sans","Liberation Sans",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"";
+    --bs-font-monospace: "'Source Code Pro Bold', SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace";
 }
 
 * {
@@ -83,16 +85,98 @@ li.certs {
 
 .monospace,
 h1,
+.h1,
 h2,
+.h2,
 h3,
+.h3,
 h4,
-h5,
-h6 {
+.h4 {
     font-family: 'Source Code Pro Bold', 'Courier New', Courier, monospace;
 }
 
-.san-serif {
+.sans-serif {
     font-family: 'Roboto', Arial, Helvetica, sans-serif;
+}
+
+/*#endregion */
+
+/*#region Headers */
+
+:root {
+    --h1-font-size: calc(40rem / 16);
+    --h1-font-weight: 700;
+    --h1-line-height: 120%;
+    --h2-font-size: calc(32rem / 16);
+    --h2-font-weight: 700;
+    --h2-line-height: 120%;
+    --h3-font-size: calc(24rem / 16);
+    --h3-font-weight: 700;
+    --h3-line-height: 120%;
+    --h4-font-size: calc(16rem / 16);
+    --h4-font-weight: 800;
+    --h4-line-height: 120%;
+    --h5-font-size: calc(16rem / 16);
+    --h5-font-weight: 500;
+    --h5-line-height: 120%;
+}
+
+@media (min-width: 992px) {
+    :root {
+        --h1-font-size: calc(48rem / 16);
+        --h1-font-weight: 800;
+        --h1-line-height: 110%;
+        --h2-font-size: calc(40rem / 16);
+        --h2-font-weight: 700;
+        --h2-line-height: 120%;
+        --h3-font-size: calc(32rem / 16);
+        --h3-font-weight: 700;
+        --h3-line-height: 120%;
+        --h4-font-size: calc(16rem / 16);
+        --h4-font-weight: 800;
+        --h4-line-height: 130%;
+        --h5-font-size: calc(16rem / 16);
+        --h5-font-weight: 500;
+        --h5-line-height: 120%;
+    }
+}
+
+h1,
+.h1 {
+    font-size: var(--h1-font-size);
+    font-weight: var(--h1-font-weight);
+    line-height: var(--h1-line-height);
+    margin: 0;
+}
+
+h2,
+.h2 {
+    font-size: var(--h2-font-size);
+    font-weight: var(--h2-font-weight);
+    line-height: var(--h2-line-height);
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+h3,
+.h3 {
+    font-size: var(--h3-font-size);
+    font-weight: var(--h3-font-weight);
+    line-height: var(--h3-line-height);
+}
+
+h4,
+.h4 {
+    font-size: var(--h4-font-size);
+    font-weight: var(--h4-font-weight);
+    line-height: var(--h4-line-height);}
+
+h5,
+.h5 {
+    font-family: var(--bs-font-sans-serif);
+    font-size: var(--h5-font-size);
+    font-weight: var(--h5-font-weight);
+    line-height: var(--h5-line-height);
 }
 
 /*#endregion */
@@ -118,41 +202,6 @@ h6 {
 .btn-link {
     font-size: var(--button-text-font-size);
 }
-
-/*
-Overwrite Bootstrap's heading font-sizes
-https://stackoverflow.com/questions/5410066/what-are-the-default-font-sizes-in-pixels-for-the-html-heading-tags-h1-h2
-*/
-
-h1 {
-    font-size: 2rem;
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-h2 {
-    font-size: 1.5rem;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
-}
-
-h3 {
-    font-size: 1.17rem;
-}
-
-h4 {
-    font-size: 1rem;
-}
-
-h5 {
-    font-size: 0.83rem;
-}
-
-h6 {
-    font-size: 0.67rem;
-}
-
-/*#endregion */
 
 .primary-btn {
     text-decoration: none;

--- a/styles/base.css
+++ b/styles/base.css
@@ -182,10 +182,6 @@ h5,
     line-height: var(--h5-line-height);
 }
 
-.posting h2 {
-    margin-top: 40px;
-}
-
 /*#endregion */
 
 /*#region Font Sizes */
@@ -351,4 +347,10 @@ footer .address {
     .brandmark {
         width: 17.5rem;
     }
+}
+
+/* Job Posting Page */
+
+.posting h2 {
+    margin-top: 40px;
 }


### PR DESCRIPTION
Closes #37 
Closes #24 

## What this PR does

### CSS

#### Headlines
- Create _classes_ for `.h1`-`.h5`, along with regular style declarations for `h1`-`h5` elements.
- Use `calc(##rem / 16)` style for font sizes

#### Font families
- Declare overrides for certain Bootstrap CSS Variables: `bs-font-sans-serif`, `bs-font-monospace`
- Correct spelling of a class - It's `sans-serif` not `san-serif`. _Sans_ means "without" in French. So it's "without serifs".

#### Links/Buttons 
- This PR doesn't touch links or buttons, as most of the changes are in the #95 PR.

#### Layouts
- Adds the ability to declare `classes` on the `<body>` element from a `layout`
- Adds the `posting` class to the `<body>` element on job post pages

### Posting page
- Correct the margin-top and margin-bottom of the `main` element on the page, for both Desktop and Mobile.
- Add the correct margin/padding bottom to the `<h1>` on the page. 
- Declare the `<h2>`s on the page to actually use _styles_ from `.h3`, so it matches the designs. 

<img width="1512" alt="image" src="https://github.com/compilerla/compiler.la/assets/3673236/523d7153-aa6d-4fb4-aa29-1226b5e2df3a">
<img width="1512" alt="image" src="https://github.com/compilerla/compiler.la/assets/3673236/acd035f2-9eca-47f7-affa-6828350f6598">

<img width="1512" alt="image" src="https://github.com/compilerla/compiler.la/assets/3673236/6b74dc64-a5b3-46a0-b23d-e40e89933ee4">

