### PR TITLE
Fix: Jobs Page, Pill

### DIFF
--- a/jobs.html
+++ b/jobs.html
@@ -5,7 +5,7 @@ title: Jobs with Compiler
 <div class="jobs container mt-5">
     <div class="row">
         <div class="col-md-8 offset-md-2 mt-5">
-            <span class="pill rounded p-2">Careers</span>
+            <span class="pill">Careers</span>
             <h1>Compiler is a woman-owned software consultancy that’s passionate about making government tech solutions
                 accessible for all.</h1>
 

--- a/jobs.html
+++ b/jobs.html
@@ -9,10 +9,10 @@ title: Jobs with Compiler
             <h1>Compiler is a woman-owned software consultancy that’s passionate about making government tech solutions
                 accessible for all.</h1>
 
-            <h2 class="mt-5 fs-5">Open roles</h2>
+            <h2 class="mt-5 fs-6">Open roles</h2>
             <ul id="open" class="list-unstyled text-decoration-none"></ul>
 
-            <h2 class="mt-5 fs-5">Past roles</h2>
+            <h2 class="mt-5 fs-6">Past roles</h2>
             <ul id="closed" class="list-unstyled"></ul>
 
             <p class="my-5">

--- a/styles/base.css
+++ b/styles/base.css
@@ -7,7 +7,6 @@
     --navy: #223061;
     --off-black: #262626;
     --black: #000000;
-    --grey: #878787;
     --white: #FFFFFF;
 }
 
@@ -196,8 +195,8 @@ h6 {
     line-height: 120%;
     letter-spacing: 0.075rem;
     text-transform: uppercase;
-    color: var(--grey);
-    border: 1px solid var(--grey);
+    color: var(--white);
+    border: 1px solid var(--white);
     border-radius: 0.375rem;
 }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -5,7 +5,7 @@
     --green: #88B440;
     --teal: #01B4CB;
     --navy: #223061;
-    --off-black: #262626;
+    --brand-primary-black: #1C1C1C;
     --black: #000000;
     --white: #FFFFFF;
 }
@@ -35,7 +35,7 @@ body {
     flex-direction: column;
 
     padding: var(--body-padding);
-    background-color: var(--off-black);
+    background-color: var(--brand-primary-black);
 
     color: var(--white);
     font-family: 'Roboto', Arial, Helvetica, sans-serif;
@@ -162,7 +162,7 @@ h6 {
     text-decoration: none;
     border: 3px solid var(--green);
     background-color: var(--green);
-    color: var(--off-black);
+    color: var(--brand-primary-black);
     padding: 1rem;
     margin-right: 15px;
     margin-bottom: 10px;
@@ -191,13 +191,14 @@ h6 {
 .pill {
     font-size: 0.75rem;
     font-family: "Source Code Pro Regular";
-    font-weight: 600;
+    font-weight: 400;
     line-height: 120%;
     letter-spacing: 0.075rem;
     text-transform: uppercase;
     color: var(--white);
-    border: 1px solid var(--white);
-    border-radius: 0.375rem;
+    border: 0.2px solid var(--white);
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.5rem;
 }
 
 /* Header */

--- a/styles/base.css
+++ b/styles/base.css
@@ -48,9 +48,9 @@ li {
 }
 
 a {
-    color: var(--white);
-    text-decoration: underline;
-    transition: 250ms;
+    color: var(--green);
+    text-decoration: none;
+    font-weight: 700;
 }
 
 li>a {


### PR DESCRIPTION
fix #102 

## What this PR does
- Pill: Pill font is now white color, with padding of 4px/8px.
- App: Body background is now darker.
- Links: Links are green, and underline on hover.

<img width="372" alt="image" src="https://github.com/compilerla/compiler.la/assets/3673236/ee6cbcb2-d0a8-423c-8e48-66696a7d6e57">
<img width="1512" alt="image" src="https://github.com/compilerla/compiler.la/assets/3673236/a18629af-0c3b-41bb-a0ee-77e1426a2a44">

## Notes
**- Border width:** Figma calls for a very thin border, of 0.2px, but both Chrome and Firefox will only allow a border as thin as 0.5px.
**- Font weight:** I think the font weights that Figma calls for are 200 over what it actually needs to be. (Or put it another way, the code expects a font weight of 500 when Figma says 700.) I confirmed this visually. I'm not sure why this is happening. This pill looks more correct with this weight than what is on Figma.

## Accessibility check
The changes in this PR bring the page up to 100% on Axe. Currently, it's failing for color contrast on production.

<img width="1512" alt="image" src="https://github.com/compilerla/compiler.la/assets/3673236/c52b7305-972a-4033-aa56-cb93fa5e26f0">
