### PR TITLE
Fix: Jobs/Posting alignment on Desktop

### DIFF
--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -3,45 +3,47 @@ layout: default
 title_prefix: "Jobs with Compiler:"
 ---
 
-<div class="row">
-  <div class="offset-md-2 col-md-7 col-12 mt-5 pt-5 mb-5 pb-5">
-    <h1 class="mt-4 pt-2">{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
+<div class="container">
+  <div class="row">
+    <div class="offset-md-2 col-md-7 col-12 mt-5 pt-5 mb-5 pb-5">
+      <h1 class="mt-4 pt-2">{{ page.title }}{% if page.type %} ({{ page.type }}){% endif %}</h1>
 
-    {{ content }} {% if page.apply_link %}
-    <a
-      class="d-inline-block monospace primary-btn"
-      id="apply"
-      href="{{ page.apply_link }}"
-    >
-      Apply Now
-    </a>
-    {% endif %}
+      {{ content }} {% if page.apply_link %}
+      <a
+        class="d-inline-block monospace primary-btn"
+        id="apply"
+        href="{{ page.apply_link }}"
+      >
+        Apply Now
+      </a>
+      {% endif %}
 
-    <p>
-      <em>
-        In keeping with our beliefs and goals, no employee or applicant will face
-        discrimination or harassment based on race, color, ancestry, national
-        origin, religion, education, age, gender identity, sexual orientation,
-        marital domestic partner status, familial status, disability status, or
-        veteran status.
-      </em>
-    </p>
-    <p>
-      <em>
-        We will consider for employment qualified applicants with arrest and
-        conviction records.
-        <a
-          href="https://bantheboxcampaign.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          #banthebox
-        </a>
-      </em>
-    </p>
+      <p>
+        <em>
+          In keeping with our beliefs and goals, no employee or applicant will face
+          discrimination or harassment based on race, color, ancestry, national
+          origin, religion, education, age, gender identity, sexual orientation,
+          marital domestic partner status, familial status, disability status, or
+          veteran status.
+        </em>
+      </p>
+      <p>
+        <em>
+          We will consider for employment qualified applicants with arrest and
+          conviction records.
+          <a
+            href="https://bantheboxcampaign.org"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            #banthebox
+          </a>
+        </em>
+      </p>
 
-    <div>
-      <a class="monospace lg-link" href="/jobs">Back to Jobs</a>
+      <div>
+        <a class="monospace lg-link" href="/jobs">Back to Jobs</a>
+      </div>
     </div>
   </div>
 </div>

--- a/jobs.html
+++ b/jobs.html
@@ -4,7 +4,7 @@ title: Jobs with Compiler
 ---
 <div class="jobs container mt-5">
     <div class="row">
-        <div class="col-md-8 offset-md-2 mt-5">
+        <div class="col-md-7 offset-md-2 mt-5">
             <span class="pill">Careers</span>
             <h1>Compiler is a woman-owned software consultancy that’s passionate about making government tech solutions
                 accessible for all.</h1>


### PR DESCRIPTION
fixes #112 

The design calls for the column-width alignment of the Jobs page and the Posting pages to be the same. They currently are not the same on Prod. This PR makes them the same:

<img width="1512" alt="image" src="https://github.com/compilerla/compiler.la/assets/3673236/0735a012-5c85-4eea-b990-c0f1283d62a3">
