### PR TITLE
Remove webrick dependency

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
             "detail": "jekyll serve --force_polling --livereload",
             "type": "shell",
             "linux": {
-                "command": "jekyll serve --force_polling --livereload"
+                "command": "bundle exec jekyll serve --force_polling --livereload"
             },
             "group": {
                 "kind": "build",

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3.2"
-gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
+    google-protobuf (3.23.4-aarch64-linux)
     google-protobuf (3.23.4-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
@@ -47,28 +48,28 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.3)
+    rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (4.1.2)
     safe_yaml (1.0.5)
-    sass-embedded (1.64.1-x86_64-linux-gnu)
+    sass-embedded (1.63.6)
       google-protobuf (~> 3.23)
-    sass-embedded (1.64.1-x86_64-linux-musl)
-      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.4.2)
     webrick (1.7.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES
   jekyll (~> 4.3.2)
-  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.3.22
+   2.4.13


### PR DESCRIPTION
Related to #92 #93 

Testing out to see if the app runs fine locally and on build without the explicit `webrick` dependency.

https://github.com/github/pages-gem/issues/752 - but we use Ruby 2.7, so we shouldn't be affected by this.

Would need to get everyone to test this on their local machines, to make sure the app still runs locally for them.

Strangely, the Mobi Mart repo https://github.com/cal-itp/mobility-marketplace/pulls is having different results with the same dependabot upgrades:
<img width="1396" alt="image" src="https://github.com/compilerla/compiler.la/assets/3673236/140c8230-beaa-47e3-a926-0f764b7dab3a">

Calitp.org doesn't have Webrick installed, and it was able to upgrade Jekyll just fine: https://github.com/cal-itp/calitp.org/blob/main/Gemfile
