### PR TITLE
Fix: button font-weight

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -178,7 +178,7 @@ h4,
     --bs-btn-padding-y: calc(1rem - 1px);
     --bs-btn-font-family: var(--bs-font-monospace);
     --bs-btn-font-size: 1rem;
-    --bs-btn-font-weight: 600;
+    --bs-btn-font-weight: 700;
     --bs-btn-line-height: 1;
     --bs-btn-border-width: calc(1rem / 16);
     --bs-btn-border-radius: 0;


### PR DESCRIPTION
The current font-weight for buttons on the live site is 600, but our Figma designs have it as 700.

![image](https://github.com/compilerla/compiler.la/assets/25497886/02b55420-712b-4706-8c13-888ec8bf5229)

![image](https://github.com/compilerla/compiler.la/assets/25497886/afe04c08-3e3b-418d-9892-d903e0fa1bdb)

This PR changes it to 700.