### PR TITLE
Fix: "Apply now" button style

### DIFF
--- a/_layouts/job_post.html
+++ b/_layouts/job_post.html
@@ -12,7 +12,7 @@ title_prefix: "Jobs with Compiler:"
         {% if page.apply_link %}
             <p>
                 <a
-                    class="d-inline-block monospace primary-btn"
+                    class="d-inline-block monospace btn btn-primary"
                     id="apply"
                     href="{{ page.apply_link }}">
                     Apply Now


### PR DESCRIPTION
@thekaveman noticed the button styles for active jobs is not working

#107 renamed the button styles, so we just needed to update the classes on this button