### PR TITLE
Replace link for career mailing list

### DIFF
--- a/jobs.html
+++ b/jobs.html
@@ -16,7 +16,7 @@ title: Jobs with Compiler
         <ul id="closed" class="list-unstyled d-flex flex-column gap-2"></ul>
 
         <p class="mt-5 mb-0">
-            Missed a past opportunity? <a href="http://eepurl.com/h6qTKL">Subscribe</a> to our mailing list, as we
+            Missed a past opportunity? <a href="https://share.hsforms.com/1yPW2aSteQS6VTeGDEyFq9gqq0e7">Subscribe</a> to our mailing list, as we
             are always looking for great candidates.
         </p>
     </div>


### PR DESCRIPTION
Closes #174 

## This PR
- Removes the Mailchimp link 
- Adds the new Hubspot link for the career mailing list form