### PR TITLE
Feat: add a blog feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3.3"
+gem "jekyll-feed"
 gem "jekyll-sass-converter", "2.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
@@ -68,6 +70,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.3.3)
+  jekyll-feed
   jekyll-sass-converter (= 2.2.0)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,8 @@ collections:
   posts:
     output: true
     permalink: /blog/:year/:title:output_ext
+feed:
+  path: /blog/feed.xml
 plugins:
   - jekyll-feed
 source: ./src

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ collections:
     output: true
     permalink: /blog/:year/:title:output_ext
 feed:
+  excerpt_only: true
   path: /blog/feed.xml
 plugins:
   - jekyll-feed

--- a/_config.yml
+++ b/_config.yml
@@ -5,4 +5,6 @@ collections:
   posts:
     output: true
     permalink: /blog/:year/:title:output_ext
+plugins:
+  - jekyll-feed
 source: ./src

--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,15 @@ collections:
   posts:
     output: true
     permalink: /blog/:year/:title:output_ext
+description: |
+  Software built by humans, for humans, in LA.
+  Compiler is a woman-owned software consultancy that’s passionate about making
+  government tech solutions easy-to-use and accessible for all.
 feed:
   excerpt_only: true
   path: /blog/feed.xml
 plugins:
   - jekyll-feed
 source: ./src
+title: Compiler
+url: https://compiler.la

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -29,6 +29,8 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
+    {% feed_meta %}
+
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"


### PR DESCRIPTION
Closes #175 

Uses [`jekyll-feed`](https://github.com/jekyll/jekyll-feed) to generate (at build time) an [Atom feed](https://en.wikipedia.org/wiki/Atom_(web_standard)) of the blog posts.

## Testing

The feed on the preview site is available here: [`https://deploy-preview-202--compilerla.netlify.app/blog/feed.xml`](https://deploy-preview-202--compilerla.netlify.app/blog/feed.xml)

I used a test channel in our Slack and subscribed to this feed with the Slack slash command:

```
/feed subscribe https://deploy-preview-202--compilerla.netlify.app/blog/feed.xml
```

And it showed me the latest post with a link back to the feed itself:

![image](https://github.com/compilerla/compiler.la/assets/1783439/f675ca2b-b7e8-4330-ad7f-fe4d44f32669)

Based on how our other `/feed subscribe`s in Slack work, I would expect to get a public update in that test channel, that looks similar to the latest post shown above, when new content is posted to the feed.