### PR TITLE
Chore: add issues to project board workflow

### DIFF
--- a/.github/workflows/add-to-project-issues.yml
+++ b/.github/workflows/add-to-project-issues.yml
@@ -1,0 +1,14 @@
+name: "Project triage: Issues"
+
+on:
+  issues:
+    types: [opened, transferred]
+
+jobs:
+  add-to-project-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/compilerla/projects/${{ vars.GH_PROJECT }}
+          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}


### PR DESCRIPTION
Closes #8 

I think the only missing part for this PR is creating the `GH_PROJECTS_TOKEN` secret. I haven't been able to find a way to do this, maybe I'm missing permissions @thekaveman ? Or if you can create it from your account that works too.