### PR TITLE
Style: remove top padding from `p` inside `li` in blog posts

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -605,7 +605,7 @@ header {
 }
 
 .blog_post p + h2,
-.blog_wrapper p:first-child {
+.blog_wrapper p:first-child:not(li > p) {
     padding-top: 56px;
 }
 


### PR DESCRIPTION
Closes #192 