### PR TITLE
Fix: convert blog categories to yaml list

### DIFF
--- a/src/_posts/2023-12-13-gift-guide.md
+++ b/src/_posts/2023-12-13-gift-guide.md
@@ -6,9 +6,11 @@ subtitle: "Searching for that perfect gift for the public service enthusiast in 
 description: "Searching for that perfect gift for the public service enthusiast in your life? Compiler’s got you covered!"
 author: Compiler Staff
 excerpt: "Eight of our favorite transit-related goodies"
-date:   2023-12-15 19:03:13 +0200
-categories: compiler
+date: 2023-12-15 19:03:13 +0200
+categories:
+  - compiler
 ---
+
 ## [1. Light Rail Snow Globe Ornament](https://shop.metro.net/collections/holiday-shop/products/light-rail-snow-globe-ornaments)
 Whoever says “I have enough ornaments, I don’t need any more” is lying! They’re lying. They want more. And they absolutely want one with an adorable little train chugging her way through a winter wonderland. (If they weren’t lying, and they don’t want this, please send it to us).
 <figure>

--- a/src/_posts/2023-12-23-welcome.md
+++ b/src/_posts/2023-12-23-welcome.md
@@ -5,8 +5,9 @@ subtitle: "What you can expect from our blog"
 description: "What you can expect from our blog"
 author: Angela Tran
 excerpt: "A quick introduction"
-date:   2023-12-14 00:00:00 +0000
-categories: compiler
+date: 2023-12-14 00:00:00 +0000
+categories:
+  - compiler
 ---
 
 ## Hello world, we are starting a blog.

--- a/src/_posts/2024-01-24-devcontainer-platform-agnostic-team.md
+++ b/src/_posts/2024-01-24-devcontainer-platform-agnostic-team.md
@@ -5,8 +5,10 @@ subtitle: "Learn from the Compiler Engineering team, which has been using VS Cod
 description: "Learn from the Compiler Engineering team, which has been using VS Code Dev Containers daily across Windows, Linux and Mac on all of their projects."
 author: Machiko Yasuda
 excerpt: "Learn from the Compiler Engineering team, which has been using VS Code Dev Containers daily across Windows, Linux and Mac on all of their projects."
-date:   2024-01-24 00:00:00 +0200
-categories: compiler, engineering
+date: 2024-01-24 00:00:00 +0200
+categories:
+  - compiler
+  - engineering
 ---
 
 The Compiler Engineering team - although quite small in teammates - has engineers working on the three main operating systems in use today: Windows, Linux and Mac. That's a very different team set-up than I've personally ever worked on over the last decade in the private sector tech world - which, for me, exclusively used Apple machines. 

--- a/src/_posts/2024-03-11-transportation-round-up.md
+++ b/src/_posts/2024-03-11-transportation-round-up.md
@@ -5,8 +5,9 @@ subtitle: "Our favorite transit stories from the past year"
 description: "Our favorite transit stories from the past year"
 author: The Compiler Team
 excerpt: "The Compiler team's favorite transit stories from the past year"
-date:   2024-03-14
-categories: compiler
+date: 2024-03-14
+categories:
+  - compiler
 ---
 
 I won’t speak for all of my Compiler colleagues, but I will say that 100% of us think that public transportation

--- a/src/_posts/2024-03-22-Civic-Tech-Career-Resources.md
+++ b/src/_posts/2024-03-22-Civic-Tech-Career-Resources.md
@@ -5,8 +5,9 @@ subtitle: "Our most used resources for navigating a career in Civic Tech"
 description: "Our most used resources for navigating a career in Civic Tech"
 author: Vyki Englert and the Compiler Team
 excerpt: "Our most used resources for navigating a career in Civic Tech"
-date:   2024-03-29
-categories: compiler
+date: 2024-03-29
+categories:
+  - compiler
 ---
 
 We first put together a list like this in the summer of 2021, when we received 242 applicants for our first-ever hire, a senior software engineer.

--- a/src/_posts/2024-04-12-open-source-development.md
+++ b/src/_posts/2024-04-12-open-source-development.md
@@ -6,7 +6,9 @@ description: "Learn from the Compiler Team about the benefits of open source dev
 author: Milo Green
 excerpt: "Learn from the Compiler Team about the benefits of open source"
 date: 2024-04-12 00:00:00 +0200
-categories: compiler, engineering
+categories:
+  - compiler
+  - engineering
 ---
 
 <figure>

--- a/src/_posts/2024-05-17-Parental-Leave-Policy.md
+++ b/src/_posts/2024-05-17-Parental-Leave-Policy.md
@@ -5,10 +5,10 @@ subtitle: "How a small, scrappy, California-based LLC created parental leave and
 description: "How a small, scrappy, California-based LLC created parental leave and wage replacement policies for its remote, multi-state team."
 author: Shelby Miller
 excerpt: "How a small, scrappy, California-based LLC created parental leave and wage replacement policies for its remote, multi-state team."
-date:   2024-05-17 19:03:13 +0200
-categories: compiler
+date: 2024-05-17 19:03:13 +0200
+categories:
+  - compiler
 ---
-
 
 In early May 2021, I excitedly looked forward to joining the Compiler team as its third Managing Partner (and only parent) later that month. Vyki Englert, Compiler’s co-founder, and I have known each other since our early 20s and worked together previously at a data-sharing startup. During that time, I told myself “When Vyki inevitably starts her own company, I want to work with her there.” We talked many times before I officially committed to joining Compiler. I shared that my husband and I planned to add to our family, “hopefully soon-ish, but you never know how that’s going to go, and in my case, it may take a while for a pregnancy to stick.”
 

--- a/src/_posts/2024-06-14-Tales-From-TCamp.md
+++ b/src/_posts/2024-06-14-Tales-From-TCamp.md
@@ -6,7 +6,8 @@ description: "The Compiler Team's key takeaways from UCLA's 2024 Transportation 
 author: Vyki Englert, Scott Frazier, Nina Dinh, Marie Araneta
 excerpt: "The Compiler Team's key takeaways from UCLA's 2024 Transportation Camp LA."
 date: 2024-06-13 19:03:13 +0200
-categories: compiler
+categories:
+  - compiler
 ---
 
 Recently, four members of the Compiler team had the opportunity to attend the latest edition of [UCLA’s Transportation Camp LA](https://www.its.ucla.edu/). Shout out


### PR DESCRIPTION
The `categories` key in a blog post's front matter is a _list_ variable -- this PR converts the CSV strings to lists.

Among other things, this allows the feed to display multiple `category` entries correctly:

_See https://deploy-preview-210--compilerla.netlify.app/blog/feed.xml_

```xml
<entry>
  <title type="html">
    How to support a platform-agnostic engineering team with VS Code Dev Containers
  </title>
  ...
  <category term="compiler"/>
  <category term="engineering"/>
  ...
</entry>
```

Whereas before this PR, they were parsed incorrectly (extra comma in `compiler`):

_See https://compiler.la/blog/feed.xml_

```xml
<entry>
  <title type="html">
    How to support a platform-agnostic engineering team with VS Code Dev Containers
  </title>
  ...
  <category term="compiler,"/>
  <category term="engineering"/>
  ...
</entry>
```