### PR TITLE
Feat: "What We've Done" - last two cards

### DIFF
--- a/src/_data/featured_work.yml
+++ b/src/_data/featured_work.yml
@@ -32,3 +32,17 @@
     - Project Management
     - Human-centered Design
     - Software Development
+
+- title: Upgrade Scenario Planning Model (SPM)
+  description: Collaborated with a diverse team to update and enhance the SPM transportation model by developing database queries and a user interface for the Southern California Association of Governments (SCAG).
+  outcome: Increased the efficiency of a PostGIS spatial query processing millions of geographic points by 70%, allowing end users to receive faster feedback and a friendlier user experience for faster data analysis.
+  tags:
+    - Software Development
+    - Human-centered Design
+
+- title: Product Schedule
+  description: Managed a research project to evaluate how well scheduling software solutions met the needs of small and rural California transit agencies. Research included conducting 30+ hours of onsite interviews with 4 agencies.
+  outcome: Deliver a research report to CalTrans summarizing research results and recommending actionable next steps to solution providers and CalTrans to provide agencies with vital scheduling resources.
+  tags:
+    - Project Management
+    - Program Development

--- a/src/our-work.html
+++ b/src/our-work.html
@@ -145,8 +145,8 @@ title: Our Work
         {% endfor %}
       </div>
 
-      <div class="row row-cols-1 row-cols-lg-2 g-4">
-        {% for featured_work in site.data.featured_work limit: 2 %}
+      <div class="row row-cols-1 row-cols-lg-2 g-4 mt-0">
+        {% for featured_work in site.data.featured_work limit: 2 offset: 4 %}
         <div class="col">
           <div class="card h-100 text-dark border-0">
             <div class="card-body px-lg-5 mx-lg-3 py-lg-5 my-lg-5 pt-3 mt-3 pb-5 pb-3 px-4 px-2">

--- a/src/our-work.html
+++ b/src/our-work.html
@@ -95,7 +95,7 @@ title: Our Work
         <div class="col">
           <div class="card h-100 text-dark border-0">
             <div class="card-body px-lg-5 mx-lg-3 py-lg-5 my-lg-5 pt-3 mt-3 pb-5 pb-3 px-4 px-2">
-              <div class="min-h-70">
+              <div class="min-h-40">
                 {% if featured_work.tags %}
                 <div class="row row-cols-1 row-cols-lg-auto g-2 g-lg-1">
                   {% for tag in featured_work.tags %}
@@ -106,6 +106,8 @@ title: Our Work
                 </div>
                 {% endif %}
                 <h3 class="card-title fw-boldest pb-4 mb-0 pb-lg-2 mb-lg-5 pt-2 pt-lg-0 mt-4">{{ featured_work.title }}</h3>
+              </div>
+              <div class="min-h-35">
                 <p class="card-text pb-2 mb-5">{{ featured_work.description }}</p>
               </div>
 
@@ -150,7 +152,7 @@ title: Our Work
         <div class="col">
           <div class="card h-100 text-dark border-0">
             <div class="card-body px-lg-5 mx-lg-3 py-lg-5 my-lg-5 pt-3 mt-3 pb-5 pb-3 px-4 px-2">
-              <div class="min-h-70">
+              <div class="min-h-40">
                 {% if featured_work.tags %}
                 <div class="row row-cols-1 row-cols-lg-auto g-2 g-lg-1">
                   {% for tag in featured_work.tags %}
@@ -161,6 +163,8 @@ title: Our Work
                 </div>
                 {% endif %}
                 <h3 class="card-title fw-boldest pb-4 mb-0 pb-lg-2 mb-lg-5 pt-2 pt-lg-0 mt-4">{{ featured_work.title }}</h3>
+              </div>
+              <div class="min-h-35">
                 <p class="card-text pb-2 mb-5">{{ featured_work.description }}</p>
               </div>
 

--- a/src/our-work.html
+++ b/src/our-work.html
@@ -144,6 +144,35 @@ title: Our Work
         </div>
         {% endfor %}
       </div>
+
+      <div class="row row-cols-1 row-cols-lg-2 g-4">
+        {% for featured_work in site.data.featured_work limit: 2 %}
+        <div class="col">
+          <div class="card h-100 text-dark border-0">
+            <div class="card-body px-lg-5 mx-lg-3 py-lg-5 my-lg-5 pt-3 mt-3 pb-5 pb-3 px-4 px-2">
+              <div class="min-h-70">
+                {% if featured_work.tags %}
+                <div class="row row-cols-1 row-cols-lg-auto g-2 g-lg-1">
+                  {% for tag in featured_work.tags %}
+                  <div class="col">
+                    <span class="pill pill-tag" aria-hidden="true">{{ tag }}</span>
+                  </div>
+                  {% endfor %}
+                </div>
+                {% endif %}
+                <h3 class="card-title fw-boldest pb-4 mb-0 pb-lg-2 mb-lg-5 pt-2 pt-lg-0 mt-4">{{ featured_work.title }}</h3>
+                <p class="card-text pb-2 mb-5">{{ featured_work.description }}</p>
+              </div>
+
+              <div>
+                <h4 class="pill fs-8 text-dark fw-boldest ps-0">Outcome</h4>
+                <p class="card-text">{{ featured_work.outcome }}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
     </div>
   </div>
 </section>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -460,6 +460,14 @@ header {
     margin: 0;
 }
 
+.min-h-35 {
+    min-height: 35%;
+}
+
+.min-h-40 {
+    min-height: 40%;
+}
+
 .min-h-70 {
     min-height: 70%;
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -468,17 +468,9 @@ header {
     min-height: 40%;
 }
 
-.min-h-70 {
-    min-height: 70%;
-}
-
 @media screen and (min-width: 992px) {
     .w-md-50 {
         width: 50% !important;
-    }
-
-    .mb-lg-6 {
-        margin-bottom: calc(96rem / 16) !important;
     }
 }
 


### PR DESCRIPTION
Part of #212

This PR adds the last two cards to the "What We've Done" section.

The `min-height` styles for card content alignment needed to be tweaked a little bit so that the "description" paragraphs would also be aligned as shown in Figma.

| Before tweaks in 2764070baa23d149d617ce6b8f04a81cdb535624 | After 2764070baa23d149d617ce6b8f04a81cdb535624 | Figma |
| --- | --- | --- |
| ![image](https://github.com/compilerla/compiler.la/assets/25497886/42d17c3f-7d05-4b34-a52a-e9493c050039) | ![image](https://github.com/compilerla/compiler.la/assets/25497886/b381f164-adc0-4e92-8e26-bbd3cef991cc) | ![image](https://github.com/compilerla/compiler.la/assets/25497886/208d425c-3404-4825-b1f8-869b6a14a037) |




Builds off the branch for https://github.com/compilerla/compiler.la/pull/224