### PR TITLE
fix: correct testimonial giver name

### DIFF
--- a/src/our-work.html
+++ b/src/our-work.html
@@ -13,10 +13,7 @@ title: Our Work
         to ensure their success.
       </p>
       <a class="btn btn-primary me-lg-3 mb-3 mb-lg-0" href="mailto:hello@compiler.la">Contact us</a>
-      <a
-        class="btn btn-outline-primary"
-        target="_blank"
-        href="/capabilities">Capabilities Statement</a>
+      <a class="btn btn-outline-primary" target="_blank" href="/capabilities">Capabilities Statement</a>
     </div>
   </div>
 </section>
@@ -39,26 +36,28 @@ title: Our Work
         <div class="row pb-5 mb-5">
           <div class="accordion" id="our-services-accordion">
             {% for service in site.data.services %}
-              <div class="accordion-item">
-                <h2 class="accordion-header" id="our-services-{{ service.id }}">
-                  <button
-                    class="accordion-button fw-boldest collapsed"
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#collapse-{{ service.id  }}"
-                    aria-expanded="false"
-                    aria-controls="collapse-{{ service.id }}">
-                    {{ service.name }}
-                  </button>
-                </h2>
-                <div
-                  id="collapse-{{ service.id }}"
-                  class="accordion-collapse collapse"
-                  aria-labelledby="our-services-{{ service.id }}"
-                  data-bs-parent="#our-services-accordion">
-                  <div class="accordion-body">{{ service.description }}</div>
-                </div>
+            <div class="accordion-item">
+              <h2 class="accordion-header" id="our-services-{{ service.id }}">
+                <button
+                  class="accordion-button fw-boldest collapsed"
+                  type="button"
+                  data-bs-toggle="collapse"
+                  data-bs-target="#collapse-{{ service.id  }}"
+                  aria-expanded="false"
+                  aria-controls="collapse-{{ service.id }}"
+                >
+                  {{ service.name }}
+                </button>
+              </h2>
+              <div
+                id="collapse-{{ service.id }}"
+                class="accordion-collapse collapse"
+                aria-labelledby="our-services-{{ service.id }}"
+                data-bs-parent="#our-services-accordion"
+              >
+                <div class="accordion-body">{{ service.description }}</div>
               </div>
+            </div>
             {% endfor %}
           </div>
         </div>
@@ -96,98 +95,91 @@ title: Our Work
       <div class="offset-lg-1 col-lg-10 mb-md-4">
         <div class="row row-cols-1 row-cols-lg-2 g-4">
           {% for featured_work in site.data.featured_work limit: 2 %}
-            <div class="col">
-              <div class="card h-100 text-dark border-0">
-                <div class="card-body px-lg-5 mx-lg-3 py-lg-5 my-lg-5 pt-3 mt-3 pb-5 pb-3 px-4 px-2">
-                  <div class="min-h-40">
-                    {% if featured_work.tags %}
-                      <div class="row row-cols-1 row-cols-lg-auto g-2 g-lg-1">
-                        {% for tag in featured_work.tags %}
-                          <div class="col">
-                            <span class="pill pill-tag" aria-hidden="true">{{ tag }}</span>
-                          </div>
-                        {% endfor %}
-                      </div>
-                    {% endif %}
-                    <h3 class="card-title fw-boldest pb-4 mb-0 pb-lg-2 mb-lg-5 pt-2 pt-lg-0 mt-4">{{ featured_work.title }}</h3>
-                  </div>
-                  <div class="min-h-35">
-                    <p class="card-text pb-2 mb-5">{{ featured_work.description }}</p>
-                  </div>
-
-                  <div>
-                    <h4 class="pill fs-8 text-dark fw-boldest ps-0">Outcome</h4>
-                    <p class="card-text">{{ featured_work.outcome }}</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          {% endfor %}
-        </div>
-
-        <div class="row row-cols-1 g-4 mt-0">
-          {% for featured_work in site.data.featured_work limit: 2 offset: 2 %}
-            {% if forloop.index0 == 0 %}
-              {% assign class = "col" %}
-            {% else %}
-              {% assign class = "col collapseMore collapse" %}
-            {% endif %}
-
-            <div class="{{ class }}">
-              <div class="card h-100 text-dark border-0">
-                <img
-                  src="{{ featured_work.image }}"
-                  class="card-img-top"
-                  alt="{{ featured_work.image_alt_text }}" />
-                <div class="card-body px-4 mx-2 p-lg-5 m-lg-2 mb-5 mb-lg-4">
+          <div class="col">
+            <div class="card h-100 text-dark border-0">
+              <div class="card-body px-lg-5 mx-lg-3 py-lg-5 my-lg-5 pt-3 mt-3 pb-5 pb-3 px-4 px-2">
+                <div class="min-h-40">
                   {% if featured_work.tags %}
-                    <div class="row row-cols-1 row-cols-lg-auto g-2 g-lg-1">
-                      {% for tag in featured_work.tags %}
-                        <div class="col">
-                          <span class="pill pill-tag" aria-hidden="true">{{ tag }}</span>
-                        </div>
-                      {% endfor %}
+                  <div class="row row-cols-1 row-cols-lg-auto g-2 g-lg-1">
+                    {% for tag in featured_work.tags %}
+                    <div class="col">
+                      <span class="pill pill-tag" aria-hidden="true">{{ tag }}</span>
                     </div>
+                    {% endfor %}
+                  </div>
                   {% endif %}
-                  <h3 class="card-title fw-boldest pt-5 mt-3 mb-4 mt-lg-2">{{ featured_work.title }}</h3>
-                  <p class="card-text pb-2 mb-4 pb-lg-0">{{ featured_work.description }}</p>
+                  <h3 class="card-title fw-boldest pb-4 mb-0 pb-lg-2 mb-lg-5 pt-2 pt-lg-0 mt-4">{{ featured_work.title }}</h3>
+                </div>
+                <div class="min-h-35">
+                  <p class="card-text pb-2 mb-5">{{ featured_work.description }}</p>
+                </div>
 
-                  <h4 class="pill fs-8 p-0 mb-3 text-dark fw-boldest">Outcome</h4>
+                <div>
+                  <h4 class="pill fs-8 text-dark fw-boldest ps-0">Outcome</h4>
                   <p class="card-text">{{ featured_work.outcome }}</p>
                 </div>
               </div>
             </div>
+          </div>
+          {% endfor %}
+        </div>
+
+        <div class="row row-cols-1 g-4 mt-0">
+          {% for featured_work in site.data.featured_work limit: 2 offset: 2 %} {% if forloop.index0 == 0 %} {% assign class =
+          "col" %} {% else %} {% assign class = "col collapseMore collapse" %} {% endif %}
+
+          <div class="{{ class }}">
+            <div class="card h-100 text-dark border-0">
+              <img src="{{ featured_work.image }}" class="card-img-top" alt="{{ featured_work.image_alt_text }}" />
+              <div class="card-body px-4 mx-2 p-lg-5 m-lg-2 mb-5 mb-lg-4">
+                {% if featured_work.tags %}
+                <div class="row row-cols-1 row-cols-lg-auto g-2 g-lg-1">
+                  {% for tag in featured_work.tags %}
+                  <div class="col">
+                    <span class="pill pill-tag" aria-hidden="true">{{ tag }}</span>
+                  </div>
+                  {% endfor %}
+                </div>
+                {% endif %}
+                <h3 class="card-title fw-boldest pt-5 mt-3 mb-4 mt-lg-2">{{ featured_work.title }}</h3>
+                <p class="card-text pb-2 mb-4 pb-lg-0">{{ featured_work.description }}</p>
+
+                <h4 class="pill fs-8 p-0 mb-3 text-dark fw-boldest">Outcome</h4>
+                <p class="card-text">{{ featured_work.outcome }}</p>
+              </div>
+            </div>
+          </div>
           {% endfor %}
         </div>
 
         <div class="row row-cols-1 row-cols-lg-2 g-4 mt-0">
           {% for featured_work in site.data.featured_work limit: 2 offset: 4 %}
-            <div class="col collapseMore collapse">
-              <div class="card h-100 text-dark border-0">
-                <div class="card-body px-lg-5 mx-lg-3 py-lg-5 my-lg-5 pt-3 mt-3 pb-5 pb-3 px-4 px-2">
-                  <div class="min-h-40">
-                    {% if featured_work.tags %}
-                      <div class="row row-cols-1 row-cols-lg-auto g-2 g-lg-1">
-                        {% for tag in featured_work.tags %}
-                          <div class="col">
-                            <span class="pill pill-tag" aria-hidden="true">{{ tag }}</span>
-                          </div>
-                        {% endfor %}
-                      </div>
-                    {% endif %}
-                    <h3 class="card-title fw-boldest pb-4 mb-0 pb-lg-2 mb-lg-5 pt-2 pt-lg-0 mt-4">{{ featured_work.title }}</h3>
+          <div class="col collapseMore collapse">
+            <div class="card h-100 text-dark border-0">
+              <div class="card-body px-lg-5 mx-lg-3 py-lg-5 my-lg-5 pt-3 mt-3 pb-5 pb-3 px-4 px-2">
+                <div class="min-h-40">
+                  {% if featured_work.tags %}
+                  <div class="row row-cols-1 row-cols-lg-auto g-2 g-lg-1">
+                    {% for tag in featured_work.tags %}
+                    <div class="col">
+                      <span class="pill pill-tag" aria-hidden="true">{{ tag }}</span>
+                    </div>
+                    {% endfor %}
                   </div>
-                  <div class="min-h-35">
-                    <p class="card-text pb-2 mb-5">{{ featured_work.description }}</p>
-                  </div>
+                  {% endif %}
+                  <h3 class="card-title fw-boldest pb-4 mb-0 pb-lg-2 mb-lg-5 pt-2 pt-lg-0 mt-4">{{ featured_work.title }}</h3>
+                </div>
+                <div class="min-h-35">
+                  <p class="card-text pb-2 mb-5">{{ featured_work.description }}</p>
+                </div>
 
-                  <div>
-                    <h4 class="pill fs-8 text-dark fw-boldest ps-0">Outcome</h4>
-                    <p class="card-text">{{ featured_work.outcome }}</p>
-                  </div>
+                <div>
+                  <h4 class="pill fs-8 text-dark fw-boldest ps-0">Outcome</h4>
+                  <p class="card-text">{{ featured_work.outcome }}</p>
                 </div>
               </div>
             </div>
+          </div>
           {% endfor %}
         </div>
         <div class="row pt-4 mt-lg-3">
@@ -200,7 +192,8 @@ title: Our Work
               role="button"
               aria-expanded="false"
               aria-label="Toggle projects"
-              aria-controls="collapseMore"></a>
+              aria-controls="collapseMore"
+            ></a>
           </div>
         </div>
       </div>
@@ -220,7 +213,7 @@ title: Our Work
           workflow for analysts. Throughout their work, they care about the end-user experience.
         </h2>
         <h3 class="fs-6 fw-normal sans-serif text-dark d-block mt-3">
-          —JungA Uhm, Principal Modeler, Southern California Association of Governments
+          —Jung A Uhm, Principal Modeler, Southern California Association of Governments
         </h3>
       </div>
     </div>


### PR DESCRIPTION
sorry for all the noise in the diff. i only opened the file in the containerized app, you can blame the prettier extension installed there.

the only substantive change in this PR is turning `—JungA Uhm` into `—Jung A Uhm`. it took a little snooping, but based on the file below i'm confident that `A` is actually a middle initial.

https://scag.ca.gov/sites/default/files/2025-03/Overall%20Work%20Program%20FY%202024-2025%20%E2%80%93%20Formal%20Amendment%20%232.pdf

another option would be to attribute the testimonial to their current name, [Jung Hak Seo](https://www.linkedin.com/in/jung-hak-seo-69a5b98)...

