### PR TITLE
Update Redirect link for ClickUp

### DIFF
--- a/src/retreat.html
+++ b/src/retreat.html
@@ -1,4 +1,4 @@
 ---
 layout: redirected
-redirect_to: https://app.clickup.com/8631512/v/dc/87d6r-2241/87d6r-37254
+redirect_to: https://app.clickup.com/8631512/v/dc/87d6r-2241/87d6r-63214
 ---


### PR DESCRIPTION
Closes #274 

In `src/retreat.html` 

Update the redirect link for the new Fall 2025 Retreat Guide 