### PR TITLE
chore(deps-dev): bump liquidjs from 10.25.3 to 10.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1202,9 +1202,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.25.3",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.3.tgz",
-      "integrity": "sha512-csoJtC6yTfkUlwy+QKm0tRbFoz5cnzly1ugFvBBDWXA4Oo8ul31hOHDEZVzG93q8YaxRIQ909GFuow8d/q1v2Q==",
+      "version": "10.27.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
+      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
recreation of #315 pointing at the branch that actually uses liquidjs