### PR TITLE
fix: assign href and title props correctly in atom feed link tag

### DIFF
--- a/src/_layouts/default.liquid
+++ b/src/_layouts/default.liquid
@@ -30,7 +30,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
     <!-- advertise the RSS feed -->
-    <link type="application/atom+xml" rel="alternate" href="{{ blog.atomPath }}" title="{{ blog.title }}">
+    <link type="application/atom+xml" rel="alternate" href="{{ feed.outputPath }}" title="{{ feed.title }}">
 
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css"


### PR DESCRIPTION
as caught out by @thekaveman in https://github.com/compilerla/compiler.la/pull/321#discussion_r3389552203

https://deploy-preview-324--compilerla.netlify.app/

<img width="743" height="78" alt="Screenshot 2026-06-10 at 9 17 59 AM" src="https://github.com/user-attachments/assets/620a46de-5f87-4aa7-a1d0-7ca2156ac118" />