### PR TITLE
Do-not-merge: draft a throwaway file to preview tables in blog posts

### DIFF
--- a/src/blog/2026-07-17-table-test.md
+++ b/src/blog/2026-07-17-table-test.md
@@ -1,0 +1,25 @@
+---
+layout: blog_post
+title: "Testing tables"
+subtitle: "A test of tables."
+description: "Test 123."
+author: Angela Tran
+excerpt: "test"
+date: 2026-07-17T00:00:00+0000
+categories:
+  - compiler
+---
+
+This is just a test.
+
+How certain conditions are defined also varies from provider to provider. For example, hearing impairments or deafness is typically a qualifying condition. But providers use different definitions with varying requirements:
+
+| Agency | Definition                                                                                                                   |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| ABC    | Hearing impairments: total deafness includes persons whose hearing loss is 70 dba or greater in the 1000 and 2000 Hz ranges. |
+| DEF    | Hard of hearing or deaf                                                                                                      |
+| XYZ    | Another definition.                                                                                                          |
+
+This now concludes the test.
+
+Goodbye.


### PR DESCRIPTION
This is to help answer a question from @cmajel in a [Google Doc comment](https://docs.google.com/document/d/1NEJdGDRJhcABHA5NEGeaMIbQJP9moaf9K6h_IKOnDH0/edit?disco=AAACDP7oqM8) in one of our draft blog posts.